### PR TITLE
Fixed compilation error in NK.h

### DIFF
--- a/evo/NK.h
+++ b/evo/NK.h
@@ -55,7 +55,7 @@ namespace evo {
       return landscape[n][state];
     }
     double GetFitness( std::vector<uint32_t> states ) const {
-      emp_assert(stats.GetSize() == N);
+      emp_assert(states.size() == N);
       double total = landscape[0][states[0]];
       for (int i = 1; i < N; i++) total += GetFitness(i,states[i]);
       return total;


### PR DESCRIPTION
Changed "stats.GetSize()" to "states.size()", which makes contextual sense. 

Gonna file an issue about getting test coverage on the evo library to prevent regressions.

@mercere99 Is this a sane change? 