### PR TITLE
updated .travis.yml to stop breaking gcov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ addons:
         - ubuntu-toolchain-r-test
         packages:
         - g++-4.8
+        - gcov
         - cmake
         - bison
         - python-virtualenv


### PR DESCRIPTION
I love it when fixes are simple.

Should address the issue mentioned here https://github.com/devosoft/Empirical/pull/76#issuecomment-223338762