### PR TITLE
Fix travis having bad gcov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
-sudo: false
+sudo: required
+dist: trusty
 language: cpp
 
 notifications:
@@ -6,8 +7,11 @@ notifications:
 
 compiler:
     - g++-4.8
+python:
+    - "3.5"
 install:
     - if [ "$CXX" = "g++" ]; then export CXX="g++-4.8" CC="gcc-4.8"; fi
+    - export python="/usr/bin/python"
 addons:
     apt:
         sources:
@@ -15,17 +19,15 @@ addons:
         - ubuntu-toolchain-r-test
         packages:
         - g++-4.8
-        - gcov
         - cmake
         - bison
         - python-virtualenv
         - python-pip
 
 before_script:
-    - make install-testing-dependencies
+    - sudo update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-4.8 90 
 
-script:
-    - source third-party/env/bin/activate
-    - cd tests
+script: 
     - git fetch origin master:refs/remotes/origin/master
+    - make travis
     - make diff-cover

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,10 @@ diff-cover: coverage
 	git diff origin/master > scripts/diff
 	cd scripts && python3 dumb_diff_cover.py -i ignore_list diff
 
+travis: 
+	cd third-party && make travis-install-dependencies
+	make diff-cover
+
 test:
 	cd tests && make test
 

--- a/third-party/Makefile
+++ b/third-party/Makefile
@@ -1,6 +1,8 @@
+travis-install-dependencies: build-doxygen
+	sudo pip install -r requirements.txt
+
 install-dependencies: build-doxygen install-pip-deps
 
-install-testing-dependencies: install-pip-deps
 
 download-doxygen:
 	bash download_doxygen.sh


### PR DESCRIPTION
To address: https://github.com/devosoft/Empirical/pull/76#issuecomment-223358796

Unfortunately this will severely slow down the travis builds--we're looking at ~5min build times.

A chunk of that is because I have travis configured to build the documentation as wel (which requires building Doxygen), so we can detect if  that starts breaking--It may be a better idea to migrate that to the code review process and include it as part of the checklist (e.g. `make test, make diff-cover, make doc...`)

@emilydolson @mercere99 opinions?