### PR TITLE
Fixes Travis build failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ language: cpp
 branches:
   only:
     - master
+    - travis_testing
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ notifications:
     on_success: change
     secure: UC8Bsb6n2WAnKdUwzGo/QwDEhSyKbJFUZCVYem11o8JpXz/PB/vLTNIt/0xhbkoAwGMivAH6i6AeLx4HhMShnt5iWq1GK5Toh+uScp1BqT3M4XnoQbmiuhKKeFJhcoFaASGIoylURXAd65fVaojSul0Lx/pztkYzNQ1FUvcwtpA/guxJ9TE5M2Vmp81T5h74InJCW8eh30UJUlWkHdChK4RxnBgDic9vmn6/DGMWBIdGDbceF3PtOHQUk3E363LFDF6Ij0rOx5oXCm0YsSblvNRxFR9MOVX2YAKPy+dM5Kx0IRlIH+yYG9heH207+cfDg4LP7PiV0eCPh5gw8s7FHr89/fM8Mubh6X+l6Wbjla4waAdMhfSdI1vGxxq5uYTEtpfzsaNNQpfMnxe4eLEpdw3FgUA6xUdSS00dkBG1RoLTtqYSGCfEkKBwzmwwbEU77SYCKu+cjtjgBJSiwC0+Dxje4Y3tb5gDLCKbDArbPWiaqaqVPtRtUbSSP7qIt9e1DaAbcJO2nun+G8y1EdHoUNWbCVqZ/70l33Oo4ssm4d38xuAqFcKv1PH+7zv8Yql4uZIDBJz8G8aVvHMlBfrKRghDakWBrKX9rFbNen5IxuV/vMF051tHc0CWlO3HQjphH5ST1/eNjywGl107VLP9HzkZzqDBKcxcSGMLi7QC7F0=
 compiler:
-- g++-5.0
+- g++-5
 python:
 - '3.5'
 install:

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -3,7 +3,7 @@ GCOV_FLAGS = -o0 -g --coverage
 TEST_NAMES = base evo geometry meta scholar tools
 FLAGS = -std=c++14
 #CXX = clang++
-CXX = g++
+#CXX = g++
 
 default: test
 


### PR DESCRIPTION
Looks like specifying CXX in tests/Makefile was causing Travis to use the wrong version of g++ (g++ points to version 4.something, so we need to run g++-5). That version doesn't support the -std=c++14 flag so everything was breaking. I'm not a Makefile wizard, so I'm not sure if there's a nice way to give the Makefile a default compiler to use when not running on Travis.

That seems to be the only problem, though!