### PR TITLE
Fix ProjectTemplate Makefile

### DIFF
--- a/examples/ProjectTemplate/Makefile
+++ b/examples/ProjectTemplate/Makefile
@@ -1,6 +1,6 @@
 # Project-specific settings
 PROJECT := project_name
-EMP_DIR := ../../Empirical
+EMP_DIR := ../../Empirical/source
 
 # Flags to use regardless of compiler
 CFLAGS_all := -Wall -Wno-unused-function -std=c++14 -I$(EMP_DIR)/


### PR DESCRIPTION
The ProjectTemplate Makefile now points into the source directory,
where the web directory and other library directories live.