### PR TITLE
Update the path to error.h in d3_init.h

### DIFF
--- a/source/web/d3/d3_init.h
+++ b/source/web/d3/d3_init.h
@@ -3,7 +3,7 @@
 
 #include <iostream>
 
-#include "../../tools/errors.h"
+#include "../../base/errors.h"
 #include "../init.h"
 #include "../JSWrap.h"
 #include "utils.h"


### PR DESCRIPTION
Fixes #147. Changes the include for `errors.h` in `web/d3/d3_init.h` from `#include "../../tools/errors.h"` to `#include "../../base/errors.h"`