### PR TITLE
Make PrintHeaderKeys optional in DataFile builders

### DIFF
--- a/source/Evolve/World.h
+++ b/source/Evolve/World.h
@@ -392,13 +392,13 @@ namespace emp {
     DataFile & SetupFile(const std::string & filename);
 
     /// Setup a file to be printed that collects fitness information over time.
-    DataFile & SetupFitnessFile(const std::string & filename="fitness.csv");
+    DataFile & SetupFitnessFile(const std::string & filename="fitness.csv", const bool & print_header=true);
 
     /// Setup a file to be printed that collects systematics information over time.
-    DataFile & SetupSystematicsFile(const std::string & filename="systematics.csv");
+    DataFile & SetupSystematicsFile(const std::string & filename="systematics.csv", const bool & print_header=true);
 
     /// Setup a file to be printed that collects population information over time.
-    DataFile & SetupPopulationFile(const std::string & filename="population.csv");
+    DataFile & SetupPopulationFile(const std::string & filename="population.csv", const bool & print_header=true);
 
     /// Setup the function to be used when fitness needs to be calculated.  The provided function
     /// should take a reference to an organism and return a fitness value of type double.
@@ -869,7 +869,7 @@ namespace emp {
 
   // A data file (default="fitness.csv") that contains information about the population's fitness.
   template<typename ORG>
-  DataFile & World<ORG>::SetupFitnessFile(const std::string & filename) {
+  DataFile & World<ORG>::SetupFitnessFile(const std::string & filename, const bool & print_header) {
     auto & file = SetupFile(filename);
     auto & node = GetFitnessDataNode();
     file.AddVar(update, "update", "Update");
@@ -877,14 +877,14 @@ namespace emp {
     file.AddMin(node, "min_fitness", "Minimum organism fitness in current population.");
     file.AddMax(node, "max_fitness", "Maximum organism fitness in current population.");
     file.AddInferiority(node, "inferiority", "Average fitness / maximum fitness in current population.");
-    file.PrintHeaderKeys();
+    if (print_header) file.PrintHeaderKeys();
     return file;
   }
 
   // A data file (default="systematics.csv") that contains information about the population's
   // phylogeny and lineages.
   template<typename ORG>
-  DataFile & World<ORG>::SetupSystematicsFile(const std::string & filename) {
+  DataFile & World<ORG>::SetupSystematicsFile(const std::string & filename, const bool & print_header) {
     auto & file = SetupFile(filename);
     file.AddVar(update, "update", "Update");
     file.template AddFun<size_t>( [this](){ return systematics.GetNumActive(); }, "num_genotypes", "Number of unique genotype groups currently active." );
@@ -893,17 +893,17 @@ namespace emp {
     file.template AddFun<size_t>( [this](){ return systematics.GetNumRoots(); }, "num_roots", "Number of independent roots for phlogenies." );
     file.template AddFun<int>( [this](){ return systematics.GetMRCADepth(); }, "mrca_depth", "Phylogenetic Depth of the Most Recent Common Ancestor (-1=none)." );
     file.template AddFun<double>( [this](){ return systematics.CalcDiversity(); }, "diversity", "Genotypic Diversity (entropy of genotypes in population)." );
-    file.PrintHeaderKeys();
+    if (print_header) file.PrintHeaderKeys();
     return file;
   }
 
   // A data file (default="population.csv") contains information about the current population.
   template<typename ORG>
-  DataFile & World<ORG>::SetupPopulationFile(const std::string & filename) {
+  DataFile & World<ORG>::SetupPopulationFile(const std::string & filename, const bool & print_header) {
     auto & file = SetupFile(filename);
     file.AddVar(update, "update", "Update");
     file.template AddFun<size_t>( [this](){ return GetNumOrgs(); }, "num_orgs", "Number of organisms currently living in the population." );
-    file.PrintHeaderKeys();
+    if (print_header) file.PrintHeaderKeys();
     return file;
   }
 


### PR DESCRIPTION
If set false, the added optional boolean argument (default true) for
SetupFitnessFile, SetupSystematicsFile, and SetupPopulationFile
suppresses the call to PrintHeaderKeys in these methods.
This allows for new columns to be added to the default Systematics,
Fitness, and Population DataFile configuration. The user is then
responsible for calling PrintHeaderKeys after adding the desired
columns have been added. This is especially useful for adding a column
with a unique identifying value for a particular replicate (e.g. seed
value), although I can imagine many other fields that a user may want
to add to these files.