### PR TITLE
Fixes errors when building attributes in debug mode.

### DIFF
--- a/source/tools/attrs.h
+++ b/source/tools/attrs.h
@@ -904,7 +904,7 @@ namespace emp {
     };
 
     template <typename... T>
-    const typename Attrs<T...>::__impl_AssignOp_asssigner_t
+    constexpr typename Attrs<T...>::__impl_AssignOp_asssigner_t
       Attrs<T...>::__impl_AssignOp_asssigner;
 
     ///  An alternative syntax for creating attribute packs. Takes any number


### PR DESCRIPTION
The problem was that, internally, attrs.h made use of a constexpr static callable struct, which needs to exist as a work around for the lack of constexpr lambdas in c++14. Constexpr static members only need to be defined outside of their class if they are odr-used at some point. According to en.cppreference.com,

> Informally, an object is odr-used if its value is read (unless it is a compile time constant) or written, its address is taken, or a reference is bound to it
-- http://en.cppreference.com/w/cpp/language/definition#ODR-use

I think that, in this case, the compiler was treating the callable struct as a constant ONLY when the optimizations were turned on. Otherwise, its value gets read, and thus it is odr-used. Since there was no definition outside of its class, this resulted in link errors. The solution was to add an out of class definition, which is also consistent with the practice in the rest of this file.