### PR TITLE
Fixing memory leak in World.h's DoBirth(genome_t,size_t,size_t) function

### DIFF
--- a/source/Evolve/World.h
+++ b/source/Evolve/World.h
@@ -1055,7 +1055,13 @@ namespace emp {
       Ptr<ORG> new_org = NewPtr<ORG>(mem);
       offspring_ready_sig.Trigger(*new_org);
       const OrgPosition pos = fun_add_birth(new_org, parent_pos);
-      if (pos.IsActive()) org_placement_sig.Trigger(pos.GetIndex());
+      if (pos.IsActive()) {
+        // If organism was placed right into the active population, trigger placement signal.
+        org_placement_sig.Trigger(pos.GetIndex());
+      } else if (!pos.IsValid()) {
+        // Organism failed to be placed in the population.  Delete it.
+        new_org.Delete();
+      }
       // SetupOrg(*new_org, &callbacks, pos);
     }
   }

--- a/source/hardware/EventDrivenGP.h
+++ b/source/hardware/EventDrivenGP.h
@@ -828,6 +828,10 @@ namespace emp {
     /// Hardware is only stochastic when calling/event affinity is equidistant from two or more functions.
     bool IsStochasticFunCall() const { return stochastic_fun_call; }
 
+    /// Get all hardware cores.
+    /// NOTE: use responsibly! 
+    emp::vector<exec_stk_t> & GetCores() { return cores; }
+
     /// Get the currently executing core ID. If hardware is not in the middle of an execution cycle
     /// (the SingleProcess function), this will return the first core ID in active_cores, which will
     /// typically be the core on which main is running.


### PR DESCRIPTION
Second of the two DoBirth functions wasn't cleaning up organisms that failed to be placed. 

Pull request has incidental update to EventDrivenGP.h (adds an accessor). 