### PR TITLE
Fixed docs; updated tests to include multiple compilers and debug modes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,18 +12,23 @@ notifications:
     - secure: UC8Bsb6n2WAnKdUwzGo/QwDEhSyKbJFUZCVYem11o8JpXz/PB/vLTNIt/0xhbkoAwGMivAH6i6AeLx4HhMShnt5iWq1GK5Toh+uScp1BqT3M4XnoQbmiuhKKeFJhcoFaASGIoylURXAd65fVaojSul0Lx/pztkYzNQ1FUvcwtpA/guxJ9TE5M2Vmp81T5h74InJCW8eh30UJUlWkHdChK4RxnBgDic9vmn6/DGMWBIdGDbceF3PtOHQUk3E363LFDF6Ij0rOx5oXCm0YsSblvNRxFR9MOVX2YAKPy+dM5Kx0IRlIH+yYG9heH207+cfDg4LP7PiV0eCPh5gw8s7FHr89/fM8Mubh6X+l6Wbjla4waAdMhfSdI1vGxxq5uYTEtpfzsaNNQpfMnxe4eLEpdw3FgUA6xUdSS00dkBG1RoLTtqYSGCfEkKBwzmwwbEU77SYCKu+cjtjgBJSiwC0+Dxje4Y3tb5gDLCKbDArbPWiaqaqVPtRtUbSSP7qIt9e1DaAbcJO2nun+G8y1EdHoUNWbCVqZ/70l33Oo4ssm4d38xuAqFcKv1PH+7zv8Yql4uZIDBJz8G8aVvHMlBfrKRghDakWBrKX9rFbNen5IxuV/vMF051tHc0CWlO3HQjphH5ST1/eNjywGl107VLP9HzkZzqDBKcxcSGMLi7QC7F0=
 compiler:
 - g++-5
+- clang++-5.0
 python:
 - '3.5'
 install:
 - if [ "$CXX" = "g++" ]; then export CXX="g++-5" CC="gcc-5"; fi
+- if [ "$CXX" = "clang++" ]; then export CXX="clang++-5.0" CC="clang-5.0"; fi
+
 - export python="/usr/bin/python"
 addons:
   apt:
     sources:
     - kalakris-cmake
     - ubuntu-toolchain-r-test
+    - llvm-toolchain-trusty-5.0
     packages:
     - g++-5
+    - clang-5.0
     - cmake
     - build-essential
     - bison

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ notifications:
 compiler:
 - g++-5
 - clang++-5.0
+- emcc
 python:
 - '3.5'
 install:
@@ -41,7 +42,11 @@ before_script:
 - export DISPLAY=:99.0
 - sh -e /etc/init.d/xvfb start
 - sleep 3 # give xvfb some time to start
-script:
 - git fetch origin master:refs/remotes/origin/master
 - npm install source-map
+- make install-dependencies
+- cd third-party && bash install_emscripten.sh
+- cd third-party && make install-npm-deps
+- . third-party/emsdk_portable_repo/emsdk_portable/emsdk_env.sh
+script:
 - make travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,6 @@ before_script:
 - cd third-party
 - bash install_emscripten.sh
 - make install-npm-deps
-- . third-party/emsdk_portable_repo/emsdk_portable/emsdk_env.sh
+- . emsdk_portable_repo/emsdk_portable/emsdk_env.sh
 script:
 - make travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,8 +45,9 @@ before_script:
 - git fetch origin master:refs/remotes/origin/master
 - npm install source-map
 - make install-dependencies
-- cd third-party && bash install_emscripten.sh
-- cd third-party && make install-npm-deps
+- cd third-party
+- bash install_emscripten.sh
+- make install-npm-deps
 - . third-party/emsdk_portable_repo/emsdk_portable/emsdk_env.sh
 script:
 - make travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,5 +49,6 @@ before_script:
 - bash install_emscripten.sh
 - make install-npm-deps
 - . emsdk_portable_repo/emsdk_portable/emsdk_env.sh
+- cd ..
 script:
 - make travis

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ build-doxygen-xml:
 	./third-party/doxygen/build/bin/doxygen Doxyfile
 
 travis: 
+	make install-dependencies
 	cd third-party && bash install_emscripten.sh
 	cd third-party && make install-npm-deps
 	make test

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 test:
 	cd tests && make test
-	cd tests && make debug
+	cd tests && make fulldebug
 	cd tests && make opt
 	cd tests && make test-web
 

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,7 @@ test:
 	cd tests && make test-web
 
 doc: build-doxygen-xml
-	doxygen
-	cd doc && make html
+	cd doc && ./make_docs.sh
 
 build-doxygen-xml:
 	./third-party/doxygen/build/bin/doxygen Doxyfile

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 test:
 	cd tests && make test
+	cd tests && make debug
+	cd tests && make opt
 	cd tests && make test-web
 
 doc: build-doxygen-xml

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ travis:
 	cd third-party && bash install_emscripten.sh
 	cd third-party && make install-npm-deps
 	make test
+	make doc
 
 install-dependencies:
 	git submodule init

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@ Empirical is a library of tools for developing efficient, reliable, and accessib
 software.  The provided code is all header-only and encapsulated into the emp namespace, so it
 is simple to incorporate into existing projects.
 
+[![Build Status](https://travis-ci.org/devosoft/Empirical.svg?branch=master)](https://travis-ci.org/devosoft/Empirical) [![Documentation Status](https://readthedocs.org/projects/empirical/badge/?version=latest)](https://empirical.readthedocs.io/en/latest/?badge=latest)
+
 See the doc/QuickStartGuides/ folder to start using the library.
 
 Tools in Empirical include:
@@ -12,7 +14,7 @@ Tools in Empirical include:
 * Many other helper tools to streamline common scientific computing tasks (configuration,
   randomization, bit manipulation, etc.)
 
-See https://empirical.readthedocs.io/en/latest/html/files.html for more detailed documentation
+See https://empirical.readthedocs.io/en/latest for more detailed documentation
 on the available source files.
 
 # Directory Structure

--- a/doc/make_docs.sh
+++ b/doc/make_docs.sh
@@ -1,4 +1,5 @@
  #!/bin/bash
 
-source ../third-party/env/bin/activate
+. ../third-party/env/bin/activate
 make html
+deactivate

--- a/doc/make_docs.sh
+++ b/doc/make_docs.sh
@@ -1,2 +1,4 @@
+ #!/bin/bash
+
 source ../third-party/env/bin/activate
 make html

--- a/doc/make_docs.sh
+++ b/doc/make_docs.sh
@@ -1,0 +1,2 @@
+source ../third-party/env/bin/activate
+make html

--- a/source/Evolve/World_select.h
+++ b/source/Evolve/World_select.h
@@ -279,7 +279,7 @@ namespace emp {
     // functions.  The best individuals on each supplemental function divide up a resource pool.
     // NOTE: You must turn off the FitnessCache for this function to work properly.
     template<typename ORG>
-    void EcoSelect(World<ORG> & world, const emp::vector<std::function<double(const ORG &)> > & extra_funs,
+    void EcoSelect(World<ORG> & world, const emp::vector<std::function<double(ORG &)> > & extra_funs,
                    const emp::vector<double> & pool_sizes, size_t t_size, size_t tourny_count=1)
     {
       emp_assert(world.GetFitFun(), "Must define a base fitness function");
@@ -304,7 +304,7 @@ namespace emp {
       for (size_t org_id = 0; org_id < world.GetSize(); org_id++) {
         base_fitness[org_id] = world.CalcFitnessID(org_id);
         for (size_t ex_id = 0; ex_id < extra_funs.size(); ex_id++) {
-          double cur_fit = extra_funs[ex_id](world[org_id]);
+          double cur_fit = extra_funs[ex_id](world.GetOrg(org_id));
           extra_fitnesses[ex_id][org_id] = cur_fit;
           if (cur_fit > max_extra_fit[ex_id]) {
             max_extra_fit[ex_id] = cur_fit;

--- a/source/tools/BitVector.h
+++ b/source/tools/BitVector.h
@@ -153,10 +153,13 @@ namespace emp {
     /// Assume that the size of the bit_set has already been adjusted to be the size of the one
     /// being copied and only the fields need to be copied over.
     void RawCopy(const Ptr<field_t> in_set) {
+      #ifdef EMP_TRACK_MEM
       emp_assert(in_set.IsNull() == false);
       emp_assert(bit_set.DebugIsArray() && in_set.DebugIsArray());
       emp_assert(bit_set.DebugGetArrayBytes() == in_set.DebugGetArrayBytes(),
                  bit_set.DebugGetArrayBytes(), in_set.DebugGetArrayBytes());
+      #endif
+      
       const size_t NUM_FIELDS = NumFields();
       for (size_t i = 0; i < NUM_FIELDS; i++) bit_set[i] = in_set[i];
     }
@@ -228,16 +231,22 @@ namespace emp {
 
     /// Copy constructor of existing bit field.
     BitVector(const BitVector & in_set) : num_bits(in_set.num_bits), bit_set(nullptr) {
+      #ifdef EMP_TRACK_MEM
       emp_assert(in_set.bit_set.IsNull() || in_set.bit_set.DebugIsArray(), in_set.bit_set.IsNull(), in_set.bit_set.DebugIsArray());
       emp_assert(in_set.bit_set.OK());
+      #endif
+
       if (num_bits) bit_set = NewArrayPtr<field_t>(NumFields());
       RawCopy(in_set.bit_set);
     }
 
     /// Move constructor of existing bit field.
     BitVector(BitVector && in_set) : num_bits(in_set.num_bits), bit_set(in_set.bit_set) {
+      #ifdef EMP_TRACK_MEM
       emp_assert(bit_set == nullptr || bit_set.DebugIsArray());
       emp_assert(bit_set.OK());
+      #endif
+
       in_set.bit_set = nullptr;
     }
 
@@ -251,9 +260,12 @@ namespace emp {
 
     /// Assignment operator.
     BitVector & operator=(const BitVector & in_set) {
+      #ifdef EMP_TRACK_MEM
       emp_assert(in_set.bit_set == nullptr || in_set.bit_set.DebugIsArray());
       emp_assert(in_set.bit_set != nullptr || in_set.num_bits == 0);
       emp_assert(in_set.bit_set.OK());
+      #endif
+      
       if (&in_set == this) return *this;
       const size_t in_num_fields = in_set.NumFields();
       const size_t prev_num_fields = NumFields();

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -17,15 +17,18 @@ test-%: test_%.cc
 	# execute test
 	./$@.out
 
+# Test in debug mode without pointer tracker
 test: test-prep $(addprefix test-, $(TEST_NAMES))
 	rm -rf test*.out
 
+# Test optimized version without debug features
 opt: FLAGS := -std=c++14 -DNDEBUG -O3 -Wno-unused-function -I../source/ -I../
 opt: test-prep $(addprefix test-, $(TEST_NAMES))
 	rm -rf test*.out
 
-debug: FLAGS := -std=c++14 -g -Wall -Wno-unused-function -I../source/ -I../ -pedantic -DEMP_TRACK_MEM -Wnon-virtual-dtor -Wcast-align -Woverloaded-virtual -ftemplate-backtrace-limit=0 # -Wmisleading-indentation
-debug: test-prep $(addprefix test-, $(TEST_NAMES))
+# Test in debug mode with pointer tracking
+fulldebug: FLAGS := -std=c++14 -g -Wall -Wno-unused-function -I../source/ -I../ -pedantic -DEMP_TRACK_MEM -Wnon-virtual-dtor -Wcast-align -Woverloaded-virtual -ftemplate-backtrace-limit=0 # -Wmisleading-indentation
+fulldebug: test-prep $(addprefix test-, $(TEST_NAMES))
 	rm -rf test*.out
 
 cranky: FLAGS := -std=c++14 -g -Wall -Wno-unused-function -I../source/ -I../ -pedantic -DEMP_TRACK_MEM -Wnon-virtual-dtor -Wcast-align -Woverloaded-virtual -Wconversion -Weffc++

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -20,7 +20,7 @@ test-%: test_%.cc
 test: test-prep $(addprefix test-, $(TEST_NAMES))
 	rm -rf test*.out
 
-opt: FLAGS := -std=c++14 -DNDEBUG -O3
+opt: FLAGS := -std=c++14 -DNDEBUG -O3 -Wno-unused-function -I../source/ -I../
 opt: test-prep $(addprefix test-, $(TEST_NAMES))
 	rm -rf test*.out
 

--- a/tests/test_assert.cc
+++ b/tests/test_assert.cc
@@ -4,9 +4,6 @@
 //
 //  Tests for files in the base/ folder.
 
-#ifndef EMP_TRACK_MEM
-#define EMP_TRACK_MEM
-#endif
 
 #define CATCH_CONFIG_MAIN
 #undef NDEBUG

--- a/tests/test_base.cc
+++ b/tests/test_base.cc
@@ -4,10 +4,6 @@
 //
 //  Tests for files in the base/ folder.
 
-#ifndef EMP_TRACK_MEM
-#define EMP_TRACK_MEM
-#endif
-
 #define EMP_DECORATE(X) [X]
 #define EMP_DECORATE_PAIR(X,Y) [X-Y]
 #define CATCH_CONFIG_MAIN
@@ -412,6 +408,7 @@ TEST_CASE("Test Ptr", "[base]")
   for (size_t i = 1; i < 10; i++) ptr_set[i] = new emp::Ptr<char>(*(ptr_set[0]));
 
   // Do we have a proper count of 10?
+  #ifndef NDEBUG
   REQUIRE(ptr_set[0]->DebugGetCount() == 10);
   ptr_set[1]->New(91);
   REQUIRE(ptr_set[0]->DebugGetCount() == 9);
@@ -421,7 +418,8 @@ TEST_CASE("Test Ptr", "[base]")
 
   ptr_set[3]->Delete();
   ptr_set[1]->Delete();
-
+  #endif 
+  
   // Make sure that we are properly handling temporary pointets moved to uninitialized pointes.
   // (Previously breaking, now fixed.)
   int a = 9;

--- a/tests/test_base.cc
+++ b/tests/test_base.cc
@@ -408,7 +408,7 @@ TEST_CASE("Test Ptr", "[base]")
   for (size_t i = 1; i < 10; i++) ptr_set[i] = new emp::Ptr<char>(*(ptr_set[0]));
 
   // Do we have a proper count of 10?
-  #ifndef NDEBUG
+  #ifdef EMP_TRACK_MEM
   REQUIRE(ptr_set[0]->DebugGetCount() == 10);
   ptr_set[1]->New(91);
   REQUIRE(ptr_set[0]->DebugGetCount() == 9);
@@ -419,8 +419,8 @@ TEST_CASE("Test Ptr", "[base]")
   ptr_set[3]->Delete();
   ptr_set[1]->Delete();
   #endif 
-  
-  // Make sure that we are properly handling temporary pointets moved to uninitialized pointes.
+
+  // Make sure that we are properly handling temporary pointers moved to uninitialized pointes.
   // (Previously breaking, now fixed.)
   int a = 9;
   emp::Ptr<int> ptr_a;

--- a/tests/test_constexpr.cc
+++ b/tests/test_constexpr.cc
@@ -4,9 +4,6 @@
 //
 //  Tests for files in the tools/ folder.
 
-#ifndef EMP_TRACK_MEM
-#define EMP_TRACK_MEM
-#endif
 
 #define EMP_DECORATE(X) [X]
 #define EMP_DECORATE_PAIR(X,Y) [X-Y]

--- a/tests/test_data.cc
+++ b/tests/test_data.cc
@@ -399,7 +399,7 @@ TEST_CASE("Test Container DataFile", "[data]") {
     
     REQUIRE(compareFiles("test_container_file.dat", "data/test_container_file.dat"));
 
-    auto dfile2 = MakeContainerDataFile(get_data, "test_make_container_file.dat");
+    auto dfile2 = emp::MakeContainerDataFile(get_data, "test_make_container_file.dat");
     dfile2.AddContainerFun(return_val, "value", "value");
     dfile2.AddContainerFun(square_val, "squared", "value squared");
 

--- a/tests/test_evo.cc
+++ b/tests/test_evo.cc
@@ -63,11 +63,11 @@ TEST_CASE("Test fitness sharing", "[evo]")
 
   pop.SetFitFun([](BitOrg &org){ return N - org.CountOnes(); });
 
-  emp::vector<std::function<double(const BitOrg&)> > fit_funs;
+  emp::vector<std::function<double(BitOrg&)> > fit_funs;
 
-  fit_funs.push_back([](const BitOrg &org){ return org.CountOnes(); });
-  fit_funs.push_back([](const BitOrg &org){ return org[0]; });
-  fit_funs.push_back([](const BitOrg &org){ return 1 - org[0]; });
+  fit_funs.push_back([](BitOrg &org){ return org.CountOnes(); });
+  fit_funs.push_back([](BitOrg &org){ return org[0]; });
+  fit_funs.push_back([](BitOrg &org){ return 1 - org[0]; });
 
   // pop.SetCache(true);
 

--- a/tests/test_geometry.cc
+++ b/tests/test_geometry.cc
@@ -29,18 +29,19 @@ TEST_CASE("Test Body2d", "[geometry]")
 
   // Start a round of replication for tests
 
-  emp::CircleBody2D & body2 = *(body1.BuildOffspring({3.0, -4.0}));
-
+  emp::Ptr<emp::CircleBody2D> body2 = body1.BuildOffspring({3.0, -4.0});
+  
   // Make sure original organism is linked to offspring.
-  REQUIRE(body1.IsLinked(body2));
-  REQUIRE(body2.IsLinked(body1));
-  REQUIRE(body1.GetLinkDist(body2) == 5.0);
-  REQUIRE(body2.GetLinkDist(body1) == 5.0);
-  REQUIRE(body1.GetTargetLinkDist(body2) == 20.0);
-  REQUIRE(body2.GetTargetLinkDist(body1) == 20.0);
+  REQUIRE(body1.IsLinked(*body2));
+  REQUIRE(body2->IsLinked(body1));
+  REQUIRE(body1.GetLinkDist(*body2) == 5.0);
+  REQUIRE(body2->GetLinkDist(body1) == 5.0);
+  REQUIRE(body1.GetTargetLinkDist(*body2) == 20.0);
+  REQUIRE(body2->GetTargetLinkDist(body1) == 20.0);
 
-  REQUIRE(body1.GetTargetLinkDist(body2) == 20);
-  REQUIRE(body2.GetTargetLinkDist(body1) == 20);
+  REQUIRE(body1.GetTargetLinkDist(*body2) == 20);
+  REQUIRE(body2->GetTargetLinkDist(body1) == 20);
+  body2.Delete();
 }
 
 

--- a/tests/test_tools.cc
+++ b/tests/test_tools.cc
@@ -4,9 +4,6 @@
 //
 //  Tests for files in the tools/ folder.
 
-#ifndef EMP_TRACK_MEM
-#define EMP_TRACK_MEM
-#endif
 
 #define EMP_DECORATE(X) [X]
 #define EMP_DECORATE_PAIR(X,Y) [X-Y]
@@ -698,21 +695,26 @@ TEST_CASE("Test mem_track", "[tools]")
   emp::vector<TestClass1 *> test_v;
   TestClass2 class2_mem;
 
+  #ifndef NDEBUG
   REQUIRE(EMP_TRACK_COUNT(TestClass1) == 0);
+  #endif
 
   for (int i = 0; i < 1000; i++) {
     test_v.push_back( new TestClass1 );
   }
 
+  #ifndef NDEBUG
   REQUIRE(EMP_TRACK_COUNT(TestClass1) == 1000);
-
+  #endif
 
   for (size_t i = 500; i < 1000; i++) {
     delete test_v[i];
   }
 
+  #ifndef NDEBUG
   REQUIRE(EMP_TRACK_COUNT(TestClass1) == 500);
   //REQUIRE(EMP_TRACK_STATUS == 0);
+  #endif
 
 }
 

--- a/tests/test_tools.cc
+++ b/tests/test_tools.cc
@@ -470,8 +470,8 @@ TEST_CASE("Test graph", "[tools]")
 
 }
 
-// TODO: add asserts
-emp::Random grand;
+// // TODO: add asserts
+// emp::Random grand;
 TEST_CASE("Test Graph utils", "[tools]")
 {
   emp::Random random;
@@ -695,7 +695,7 @@ TEST_CASE("Test mem_track", "[tools]")
   emp::vector<TestClass1 *> test_v;
   TestClass2 class2_mem;
 
-  #ifndef NDEBUG
+  #ifdef EMP_TRACK_MEM
   REQUIRE(EMP_TRACK_COUNT(TestClass1) == 0);
   #endif
 
@@ -703,7 +703,7 @@ TEST_CASE("Test mem_track", "[tools]")
     test_v.push_back( new TestClass1 );
   }
 
-  #ifndef NDEBUG
+  #ifdef EMP_TRACK_MEM
   REQUIRE(EMP_TRACK_COUNT(TestClass1) == 1000);
   #endif
 
@@ -711,7 +711,7 @@ TEST_CASE("Test mem_track", "[tools]")
     delete test_v[i];
   }
 
-  #ifndef NDEBUG
+  #ifdef EMP_TRACK_MEM
   REQUIRE(EMP_TRACK_COUNT(TestClass1) == 500);
   //REQUIRE(EMP_TRACK_STATUS == 0);
   #endif

--- a/third-party/requirements.txt
+++ b/third-party/requirements.txt
@@ -1,4 +1,6 @@
-sphinx
+sphinx==1.6.6
 breathe
 gcovr
-diff-cover
+diff
+sphinx_rtd_theme
+


### PR DESCRIPTION
This pull request:

- Fixes the current build of the docs (and simplifies the process of installing development dependencies)
- Adds building the docs to the automated testing so we'll know if they break
- Adds badges to the readme showing current testing and docs status, so it's harder for us to miss it when they fail
- Adds clang and emscripten as compilers that get used to build tests
- Runs all tests in full debug mode (including pointer tracking), debug mode without pointer tracking, and in optimized mode (no debugging, O3 optimizations)