### PR TITLE
Bug fix in systematics and some tidying

### DIFF
--- a/source/Evolve/Systematics.h
+++ b/source/Evolve/Systematics.h
@@ -14,7 +14,7 @@
  *  @todo This inheritance system makes adding new systematics-related data tracking kind of a pain.
  *        Over time, this will probably become a maintainability problem. We can probably make the
  *        whole inheritance thing go away through judicious use of signals.
- * @todo This does not currently handle situations where organisms change locations during their 
+ * @todo This does not currently handle situations where organisms change locations during their
  *       lifetimes gracefully.
  */
 
@@ -39,7 +39,7 @@
 
 namespace emp {
 
-  /// The systematics manager allows an optional second template type that 
+  /// The systematics manager allows an optional second template type that
   /// can store additional data about each taxon in the phylogeny. Here are
   /// some structs containing common pieces of additional data to track.
   /// Note: You are responsible for filling these in! Adding the template
@@ -52,9 +52,9 @@ namespace emp {
         using has_phen_t = std::false_type;
     }; /// The default - an empty struct
 
-    template <typename PHEN_TYPE> 
+    template <typename PHEN_TYPE>
     struct mut_landscape_info { /// Track information related to the mutational landscape
-      /// Maps a string representing a type of mutation to a count representing 
+      /// Maps a string representing a type of mutation to a count representing
       /// the number of that type of mutation that occured to bring about this taxon.
       using phen_t = PHEN_TYPE;
       using has_phen_t = std::true_type;
@@ -174,7 +174,7 @@ namespace emp {
     }
 
     /// Get total number of offspring directly or indirectly
-    /// descending from this taxon. 
+    /// descending from this taxon.
     int GetTotalOffspring(){ return total_offspring; }
 
     /// Remove an organism from this Taxon (after it dies).
@@ -512,7 +512,7 @@ namespace emp {
     /// Argument: Pounter to taxon
     SignalKey OnPrune(std::function<void(Ptr<taxon_t>)> & fun) { return on_prune_sig.AddAction(fun); }
 
-    virtual data_ptr_t 
+    virtual data_ptr_t
     AddEvolutionaryDistinctivenessDataNode(const std::string & name = "evolutionary_distinctiveness") {
       auto node = AddDataNode(name);
       node->AddPullSet([this](){
@@ -543,7 +543,7 @@ namespace emp {
     }
 
 
-    virtual data_ptr_t 
+    virtual data_ptr_t
     AddDeleteriousStepDataNode(const std::string & name = "deleterious_steps") {
       return AddDeleteriousStepDataNodeImpl(1, name);
     }
@@ -552,7 +552,7 @@ namespace emp {
       emp_assert(false, "Calculating deleterious steps requires suitable DATA_STRUCT");
       return AddDataNode(name);
     }
- 
+
     template <typename T=int>
     data_ptr_t
     AddDeleteriousStepDataNodeImpl(typename std::enable_if<DATA_STRUCT::has_fitness_t::value, T>::type decoy, const std::string & name = "deleterious_steps") {
@@ -568,7 +568,7 @@ namespace emp {
       return node;
     }
 
-    virtual data_ptr_t 
+    virtual data_ptr_t
     AddVolatilityDataNode(const std::string & name = "volatility") {
       return AddVolatilityDataNodeImpl(1, name);
     }
@@ -577,7 +577,7 @@ namespace emp {
       emp_assert(false, "Calculating taxon volatility requires suitable DATA_STRUCT");
       return AddDataNode(name);
     }
- 
+
     template <typename T=int>
     data_ptr_t
     AddVolatilityDataNodeImpl(typename std::enable_if<DATA_STRUCT::has_phen_t::value, T>::type decoy, const std::string & name = "volatility") {
@@ -593,7 +593,7 @@ namespace emp {
       return node;
     }
 
-    virtual data_ptr_t 
+    virtual data_ptr_t
     AddUniqueTaxaDataNode(const std::string & name = "unique_taxa") {
       return AddUniqueTaxaDataNodeImpl(1, name);
     }
@@ -602,7 +602,7 @@ namespace emp {
       emp_assert(false, "Calculating uniqe taxa requires suitable DATA_STRUCT");
       return AddDataNode(name);
     }
- 
+
     template <typename T=int>
     data_ptr_t
     AddUniqueTaxaDataNodeImpl(typename std::enable_if<DATA_STRUCT::has_phen_t::value, T>::type decoy, const std::string & name = "unique_taxa") {
@@ -618,7 +618,7 @@ namespace emp {
       return node;
     }
 
-    virtual data_ptr_t 
+    virtual data_ptr_t
     AddMutationCountDataNode(const std::string & name = "mutation_count", const std::string & mutation = "substitution") {
       return AddMutationCountDataNodeImpl(1, name, mutation);
     }
@@ -627,7 +627,7 @@ namespace emp {
       emp_assert(false, "Calculating mutation count requires suitable DATA_STRUCT");
       return AddDataNode(name);
     }
- 
+
     template <typename T=int>
     data_ptr_t
     AddMutationCountDataNodeImpl(typename std::enable_if<DATA_STRUCT::has_mutations_t::value, T>::type decoy, const std::string & name = "mutation_count", const std::string & mutation = "substitution") {
@@ -655,10 +655,10 @@ namespace emp {
       return next_taxon_locations[id];
     }
 
-    /** From (Faith 1992, reviewed in Winters et al., 2013), phylogenetic diversity is 
-     *  the sum of edges in the minimal spanning tree connected the taxa you're 
+    /** From (Faith 1992, reviewed in Winters et al., 2013), phylogenetic diversity is
+     *  the sum of edges in the minimal spanning tree connected the taxa you're
      *  calculating diversity of.
-     * 
+     *
      * This calculates phylogenetic diversity for all extant taxa in the tree, assuming
      * all edges from parent to child have a length of one. Possible extensions to this
      * function that might be useful in the future include:
@@ -666,28 +666,28 @@ namespace emp {
      * - Enable calculation of branch lengths by amount of time that elapsed between
      *   origination of parent and origination of offspring
      * - Enable a paleontology compatibility mode where only branching points are calculated
-     */ 
+     */
     int GetPhylogeneticDiversity() const {
       // As shown on page 5 of Faith 1992, when all branch lengths are equal the phylogenetic
       // diversity is the number of internal nodes plus the number of extant taxa - 1.
       return ancestor_taxa.size() + active_taxa.size() - 1;
     }
- 
+
     /** This is a metric of how distinct @param tax is from the rest of the population.
-     * 
+     *
      * (From Vane-Wright et al., 1991; reviewed in Winter et al., 2013)
     */
     double GetTaxonDistinctiveness(Ptr<taxon_t> tax) const {return 1.0/GetDistanceToRoot(tax);}
 
     /** This metric (from Isaac, 2007; reviewd in Winter et al., 2013) measures how
      * distinct @param tax is from the rest of the population, weighted for the amount of
-     * unique evolutionary history that it represents. 
-     * 
+     * unique evolutionary history that it represents.
+     *
      * To quantify length of evolutionary history, this method needs @param time: the current
      * time, in whatever units time is being measured in when taxa are added to the systematics
      * manager. Note that passing a time in the past will produce innacurate results (since we
      * don't know what the state of the tree was at that time).
-     * 
+     *
      * Assumes the tree is all connected. Will return -1 if this assumption isn't met.
     */
     double GetEvolutionaryDistinctiveness(Ptr<taxon_t> tax, double time) const {
@@ -708,14 +708,14 @@ namespace emp {
       Ptr<taxon_t> test_taxon = tax->GetParent();
 
       emp_assert(time != -1 && "Invalid time - are you passing time to rg?", time);
-      emp_assert(time >= tax->GetOriginationTime() 
+      emp_assert(time >= tax->GetOriginationTime()
                  && "GetEvolutionaryDistinctiveness recieved a time that is earlier than the taxon's origination time.");
 
       while (test_taxon) {
 
-        emp_assert(test_taxon->GetOriginationTime() != -1 && 
+        emp_assert(test_taxon->GetOriginationTime() != -1 &&
                   "Invalid time - are you passing time to rg?");
-        
+
         depth += time - test_taxon->GetOriginationTime();
         // std::cout << "Tax: " << test_taxon->GetID() << " depth: " << depth << " time: " << time  << " Orig: " << test_taxon->GetOriginationTime() << " divisor: " << divisor << std::endl;
         time = test_taxon->GetOriginationTime();
@@ -724,7 +724,7 @@ namespace emp {
           // std::cout << (int)(test_taxon == mrca) << " depth: " << depth << " divisor: " << divisor << std::endl;
           total += depth/divisor;
           return total;
-        } else if (test_taxon->GetNumOrgs() > 0) { 
+        } else if (test_taxon->GetNumOrgs() > 0) {
           // If this taxon is still alive we need to update the divisor
           // std::cout << "Alive point" << " depth: " << depth << " divisor: " << divisor << std::endl;
           total += depth/divisor;
@@ -740,7 +740,7 @@ namespace emp {
 
         test_taxon = test_taxon->GetParent();
       }
-    
+
       return -1;
     }
 
@@ -748,11 +748,11 @@ namespace emp {
      * This measurement is also called Average Taxonomic Diversity (Warwick and Clark, 1998)
      * (for demonstration of equivalence see Tucker et al, 2016). This measurment tells
      * you about the amount of distinctness in the community as a whole.
-     * 
+     *
      * @param branch_only only counts distance in terms of nodes that represent a branch
      * between two extant taxa (poentially useful for comparison to biological data, where
      * non-branching nodes generally cannot be inferred).
-     * 
+     *
      * This measurement assumes that the tree is fully connected. Will return -1
      * if this is not the case.
      * */
@@ -763,11 +763,11 @@ namespace emp {
 
     /** Calculates summed pairwise distance between extant taxa. Tucker et al 2017 points
      *  out that this is a measure of phylogenetic richness.
-     * 
+     *
      * @param branch_only only counts distance in terms of nodes that represent a branch
      * between two extant taxa (poentially useful for comparison to biological data, where
      * non-branching nodes generally cannot be inferred).
-     * 
+     *
      * This measurement assumes that the tree is fully connected. Will return -1
      * if this is not the case.
      * */
@@ -778,11 +778,11 @@ namespace emp {
 
     /** Calculates variance of pairwise distance between extant taxa. Tucker et al 2017 points
      *  out that this is a measure of phylogenetic regularity.
-     * 
+     *
      * @param branch_only only counts distance in terms of nodes that represent a branch
      * between two extant taxa (poentially useful for comparison to biological data, where
      * non-branching nodes generally cannot be inferred).
-     * 
+     *
      * This measurement assumes that the tree is fully connected. Will return -1
      * if this is not the case.
      * */
@@ -792,26 +792,26 @@ namespace emp {
     }
 
     /** Calculates a vector of all pairwise distances between extant taxa.
-     * 
+     *
      * @param branch_only only counts distance in terms of nodes that represent a branch
      * between two extant taxa (poentially useful for comparison to biological data, where
      * non-branching nodes generally cannot be inferred).
-     * 
+     *
      * This method assumes that the tree is fully connected. Will return -1
      * if this is not the case.
      * */
-    emp::vector<double> GetPairwiseDistances(bool branch_only=false) const {      
+    emp::vector<double> GetPairwiseDistances(bool branch_only=false) const {
       // The overarching approach here is to start with a bunch of pointers to all
       // extant organisms (since that will include all leaves). Then we trace back up
       // the tree, keeping track of distances. When things meet up, we calculate
       // distances between the nodes on the sides that just met up.
 
       emp::vector<double> dists;
-      
+
       std::map< Ptr<taxon_t>, emp::vector<emp::vector<int>> > curr_pointers;
       std::map< Ptr<taxon_t>, emp::vector<emp::vector<int>> > next_pointers;
 
-      
+
       for (Ptr<taxon_t> tax : active_taxa) {
         curr_pointers[tax] = emp::vector<emp::vector<int>>({{0}});
       }
@@ -830,7 +830,7 @@ namespace emp {
               }
             } else {
               next_pointers[tax.first] = curr_pointers[tax.first];
-            } 
+            }
             continue;
           }
           emp_assert(tax.first->GetNumOff() + int(alive) == tax.second.size(), tax.first->GetNumOff(), alive, to_string(tax.second), tax.second.size());
@@ -839,7 +839,7 @@ namespace emp {
           // between everything that just met.
 
           if (tax.second.size() > 1) {
-       
+
             for (size_t i = 0; i < tax.second.size(); i++ ) {
               for (size_t j = i+1; j < tax.second.size(); j++) {
                 for (int disti : tax.second[i]) {
@@ -851,16 +851,16 @@ namespace emp {
               }
             }
           }
-          // std::cout << "dists " << to_string(dists) << std::endl; 
+          // std::cout << "dists " << to_string(dists) << std::endl;
           // Increment distances and stick them in new vector
-          emp::vector<int> new_dist_vec; 
+          emp::vector<int> new_dist_vec;
           for (auto & vec : tax.second) {
             for (int el : vec) {
               new_dist_vec.push_back(el+1);
             }
           }
 
-          // std::cout << "new_dist_vec " << to_string(new_dist_vec) << std::endl; 
+          // std::cout << "new_dist_vec " << to_string(new_dist_vec) << std::endl;
 
           next_pointers.erase(tax.first);
 
@@ -919,7 +919,7 @@ namespace emp {
       return depth;
     }
 
-    /** Counts the number of branching points leading to multiple extant taxa 
+    /** Counts the number of branching points leading to multiple extant taxa
      * between @param tax and the most-recent common ancestor (or the root of its subtree,
      * if no MRCA exists). This is useful because a lot
      * of stats for phylogenies are designed for phylogenies reconstructed from extant taxa.
@@ -1016,10 +1016,10 @@ namespace emp {
   void Systematics<ORG, ORG_INFO, DATA_STRUCT>::MarkExtinct(Ptr<taxon_t> taxon) {
     emp_assert(taxon);
     emp_assert(taxon->GetNumOrgs() == 0);
-    
+
     if (taxon->GetParent()) {
       // Update extant descendant count for all ancestors
-      taxon->GetParent()->RemoveTotalOffspring(); 
+      taxon->GetParent()->RemoveTotalOffspring();
     }
 
     if (store_active) active_taxa.erase(taxon);
@@ -1070,7 +1070,7 @@ namespace emp {
   // Add information about a new organism, including its stored info and parent's taxon;
   // Can't return a pointer for the associated taxon because of obnoxious inheritance problems
   template <typename ORG, typename ORG_INFO, typename DATA_STRUCT>
-  // Ptr<typename Systematics<ORG, ORG_INFO, DATA_STRUCT>::taxon_t> 
+  // Ptr<typename Systematics<ORG, ORG_INFO, DATA_STRUCT>::taxon_t>
   void Systematics<ORG, ORG_INFO, DATA_STRUCT>::AddOrg(ORG & org, int pos, int update, bool next) {
     emp_assert(store_position, "Trying to pass position to a systematics manager that can't use it");
     // emp_assert(next_parent, "Adding organism with no parent specified and no next_parent set");
@@ -1081,7 +1081,7 @@ namespace emp {
   // Add information about a new organism, including its stored info and parent's taxon;
   // Can't return a pointer for the associated taxon because of obnoxious inheritance problems
   template <typename ORG, typename ORG_INFO, typename DATA_STRUCT>
-  // Ptr<typename Systematics<ORG, ORG_INFO, DATA_STRUCT>::taxon_t> 
+  // Ptr<typename Systematics<ORG, ORG_INFO, DATA_STRUCT>::taxon_t>
   void Systematics<ORG, ORG_INFO, DATA_STRUCT>::AddOrg(ORG && org, int pos, int update, bool next) {
     emp_assert(store_position, "Trying to pass position to a systematics manager that can't use it");
     // emp_assert(next_parent, "Adding organism with no parent specified and no next_parent set");
@@ -1092,14 +1092,14 @@ namespace emp {
 
   // Version for if you aren't tracking positions
   template <typename ORG, typename ORG_INFO, typename DATA_STRUCT>
-  Ptr<typename Systematics<ORG, ORG_INFO, DATA_STRUCT>::taxon_t> 
+  Ptr<typename Systematics<ORG, ORG_INFO, DATA_STRUCT>::taxon_t>
   Systematics<ORG, ORG_INFO, DATA_STRUCT>::AddOrg(ORG & org, Ptr<taxon_t> parent, int update, bool next) {
     return AddOrg(org, -1, parent, update, next);
   }
 
   // Version for if you aren't tracking positions
   template <typename ORG, typename ORG_INFO, typename DATA_STRUCT>
-  Ptr<typename Systematics<ORG, ORG_INFO, DATA_STRUCT>::taxon_t> 
+  Ptr<typename Systematics<ORG, ORG_INFO, DATA_STRUCT>::taxon_t>
   Systematics<ORG, ORG_INFO, DATA_STRUCT>::AddOrg(ORG && org, Ptr<taxon_t> parent, int update, bool next) {
     return AddOrg(org, -1, parent, update, next);
   }
@@ -1128,7 +1128,7 @@ namespace emp {
       if (!cur_taxon) {                                 // No parent -> NEW tree
         num_roots++;                                    // ...track extra root.
         mrca = nullptr;                                 // ...nix old common ancestor
-      } 
+      }
 
       cur_taxon = NewPtr<taxon_t>(++next_id, info, parent);  // Build new taxon.
       on_new_sig.Trigger(cur_taxon);

--- a/source/Evolve/Systematics.h
+++ b/source/Evolve/Systematics.h
@@ -463,8 +463,10 @@ namespace emp {
 
     void Update() {
       ++curr_update;
-      std::swap(taxon_locations, next_taxon_locations);
-      next_taxon_locations.resize(0);
+      if (track_synchronous) {
+        std::swap(taxon_locations, next_taxon_locations);
+        next_taxon_locations.resize(0);
+      }
     }
 
     void SetCalcInfoFun(fun_calc_info_t f) {calc_info_fun = f;}

--- a/source/Evolve/SystematicsAnalysis.h
+++ b/source/Evolve/SystematicsAnalysis.h
@@ -2,7 +2,7 @@
  *  @note This file is part of Empirical, https://github.com/devosoft/Empirical
  *  @copyright Copyright (C) Michigan State University, MIT Software license; see doc/LICENSE.md
  *  @date 2018
- * 
+ *
  * This file contains extra analysis tools to use with systematics managers that
  * have non-null DATA_TYPES.
 **/
@@ -30,7 +30,7 @@ namespace emp {
 
         while (taxon) {
             count++;
-            taxon = taxon->GetParent();            
+            taxon = taxon->GetParent();
         }
 
         return count;
@@ -46,7 +46,7 @@ namespace emp {
 
         while (taxon) {
             count += (int)(taxon->GetData().mut_counts[type] > 0);
-            taxon = taxon->GetParent();            
+            taxon = taxon->GetParent();
         }
 
         return count;
@@ -64,7 +64,7 @@ namespace emp {
             for (std::string type : types) {
                 count += (int)(taxon->GetData().mut_counts[type] > 0);
             }
-            taxon = taxon->GetParent();            
+            taxon = taxon->GetParent();
         }
 
         return count;
@@ -78,7 +78,7 @@ namespace emp {
 
         while (taxon) {
             count += taxon->GetData().mut_counts[type];
-            taxon = taxon->GetParent();            
+            taxon = taxon->GetParent();
         }
 
         return count;
@@ -94,7 +94,7 @@ namespace emp {
             for (std::string type : types) {
                 count += taxon->GetData().mut_counts[type];
             }
-            taxon = taxon->GetParent();            
+            taxon = taxon->GetParent();
         }
 
         return count;
@@ -113,8 +113,8 @@ namespace emp {
             if (taxon->GetData().GetFitness() < parent->GetData().GetFitness()) {
                 count++;
             }
-            taxon = parent;            
-            parent = taxon->GetParent();               
+            taxon = parent;
+            parent = taxon->GetParent();
         }
 
         return count;
@@ -131,8 +131,8 @@ namespace emp {
             if (taxon->GetData().phenotype != parent->GetData().phenotype) {
                 count++;
             }
-            taxon = parent;            
-            parent = taxon->GetParent();               
+            taxon = parent;
+            parent = taxon->GetParent();
         }
 
         return count;
@@ -142,7 +142,7 @@ namespace emp {
     /// along @param taxon 's lineage.
     template <typename taxon_t>
     int CountUniquePhenotypes(Ptr<taxon_t> taxon) {
-        int count = 0; 
+        int count = 0;
         std::set<decltype(taxon->GetData().phenotype)> seen;
 
         while (taxon) {
@@ -150,7 +150,7 @@ namespace emp {
                 count++;
                 seen.insert(taxon->GetData().phenotype);
             }
-            taxon = taxon->GetParent();               
+            taxon = taxon->GetParent();
         }
 
         return count;

--- a/source/Evolve/World.h
+++ b/source/Evolve/World.h
@@ -344,28 +344,28 @@ namespace emp {
     /// Get a systematics manager (which is tracking lineages in the population.)
     /// @param id - which systematics manager to return? Systematics managers are
     /// stored in the order they are added to the world.
-    Ptr<SystematicsBase<ORG> > GetSystematics(int id=0) { 
+    Ptr<SystematicsBase<ORG> > GetSystematics(int id=0) {
       emp_assert(systematics.size() > 0, "Cannot get systematics file. No systematics file to track.");
       emp_assert(id < (int)systematics.size(), "Invalid systematics file requested.", id, systematics.size());
-      return systematics[id]; 
+      return systematics[id];
     }
 
     /// Get a systematics manager (which is tracking lineages in the population.)
     /// @param id - which systematics manager to return? Systematics managers are
     /// stored in the order they are added to the world.
-    Ptr<SystematicsBase<ORG> > GetSystematics(std::string label) { 
+    Ptr<SystematicsBase<ORG> > GetSystematics(std::string label) {
       emp_assert(Has(systematics_labels, label), "Invalid systematics manager label");
 
-      return systematics[systematics_labels[label]]; 
+      return systematics[systematics_labels[label]];
     }
 
 
-    void RemoveSystematics(int id) { 
+    void RemoveSystematics(int id) {
       emp_assert(systematics.size() > 0, "Cannot remove systematics file. No systematics file to track.");
       emp_assert(id < systematics.size(), "Invalid systematics file requested to be removed.", id, systematics.size());
-      
-      systematics[id].Delete(); 
-      systematics[id] = nullptr; 
+
+      systematics[id].Delete();
+      systematics[id] = nullptr;
 
       for (auto el : systematics_labels) {
         if (el.second == id) {
@@ -374,10 +374,10 @@ namespace emp {
       }
     }
 
-    void RemoveSystematics(std::string label) { 
+    void RemoveSystematics(std::string label) {
       emp_assert(Has(systematics_labels, label), "Invalid systematics manager label");
 
-      systematics[systematics_labels[label]].Delete(); 
+      systematics[systematics_labels[label]].Delete();
       systematics[systematics_labels[label]] = nullptr;
       systematics_labels.erase(label) ;
     }
@@ -870,7 +870,7 @@ namespace emp {
     pops.MakeValid(pos);                 // Make sure we have room for new organism
     pops(pos) = new_org;                 // Put org into place.
 
-    // Track org count 
+    // Track org count
     if (pos.IsActive()) ++num_orgs;
 
     // Track the new systematics info
@@ -937,7 +937,7 @@ namespace emp {
         emp_assert(new_org);      // New organism must exist.
         return WorldPosition(pops[1].size(), 1);   // Append it to the NEXT population
       };
-      
+
       SetAttribute("SynchronousGen", "True");
     } else {
       // Asynchronous: always append to current population.
@@ -947,7 +947,7 @@ namespace emp {
       SetAttribute("SynchronousGen", "False");
     }
 
-    SetAttribute("PopStruct", "Grow");    
+    SetAttribute("PopStruct", "Grow");
     SetSynchronousSystematics(synchronous_gen);
   }
 
@@ -1148,7 +1148,7 @@ namespace emp {
       for (size_t i = 0; i < pops[1].size(); i++) {
         if (!pops[1][i]) continue;
         before_placement_sig.Trigger(*pops[1][i], i);  // Trigger that org is about to be placed.
-      } 
+      }
 
       // Clear out current pop.
       for (size_t i = 0; i < pop.size(); i++) RemoveOrgAt(i);

--- a/source/Evolve/World_reflect.h
+++ b/source/Evolve/World_reflect.h
@@ -5,12 +5,12 @@
  *
  *  @file  World_reflect.h
  *  @brief Handle reflection on organisms to setup reasonable defaults in World.
- * 
+ *
  *  @note None of the functions defined here should be called from outside the world object;
  *        as such the comments below are not in Doxygen format and should only be used by
  *        LIBRARY developers working on World.
  */
-  
+
 #ifndef EMP_EVO_WORLD_REFLECT_H
 #define EMP_EVO_WORLD_REFLECT_H
 

--- a/source/Evolve/World_select.h
+++ b/source/Evolve/World_select.h
@@ -158,7 +158,7 @@ namespace emp {
     emp_assert(fit_funs.size() > 0);
 
     // @CAO: Can probably optimize a bit!
-    
+
     std::map<typename ORG::genome_t, int> genotype_counts;
     emp::vector<emp::vector<size_t>> genotype_lists;
 
@@ -227,7 +227,7 @@ namespace emp {
         next_gens.push_back(cur_gens[0]);
         // std::cout << "Starting max: " << max_fit << to_string(cur_gens) << std::endl;
         for (size_t gen_id : cur_gens) {
-              
+
           const double cur_fit = fitnesses[fit_id][gen_id];
           // std::cout << "gen_id: " << gen_id << "Fit: " << cur_fit << std::endl;
           if (cur_fit > max_fit) {
@@ -244,7 +244,7 @@ namespace emp {
         // Make next_orgs into new cur_orgs; make cur_orgs allocated space for next_orgs.
         std::swap(cur_gens, next_gens);
         next_gens.resize(0);
-        
+
         if (cur_gens.size() == 1) break;  // Stop if we're down to just one organism.
       }
 

--- a/source/Evolve/World_structure.h
+++ b/source/Evolve/World_structure.h
@@ -81,7 +81,7 @@ namespace emp {
       }
     }
 
-    T & operator()(WorldPosition pos) { 
+    T & operator()(WorldPosition pos) {
       const size_t pop_id = pos.GetPopID();
       const size_t id = pos.GetIndex();
       return base_t::operator[](pop_id)[id];
@@ -275,7 +275,7 @@ namespace emp {
     emp::vector<double> max_vals;    ///< Largest value found for each trait.
     emp::vector<double> bin_width;   ///< Largest value found for each trait.
 
-    bool is_setup;                          ///< Have we initialized the internal data stucture? 
+    bool is_setup;                          ///< Have we initialized the internal data stucture?
     size_t num_trait_bins;                  ///< How many bins should we use for each trait?
     size_t num_total_bins;                  ///< How many bins are there overall?
     emp::vector<std::set<size_t>> bin_ids;  ///< Which org ids fall into each bin?
@@ -308,7 +308,7 @@ namespace emp {
         }
         if (cur_dist < distance[id2]) {
           distance[id2] = cur_dist;
-          nearest_id[id2] = refresh_id;   
+          nearest_id[id2] = refresh_id;
         }
       }
     }
@@ -425,18 +425,18 @@ namespace emp {
       bool update_chart = false;
       emp::vector<double> cur_vals = traits.EvalValues(world.GetOrg(pos));
       for (size_t i = 0; i < cur_vals.size(); i++) {
-        if (cur_vals[i] <= min_vals[i]) { 
+        if (cur_vals[i] <= min_vals[i]) {
           min_vals[i] = cur_vals[i] - bin_width[i]/2.0;
           update_chart = true;
         }
-        if (cur_vals[i] >= max_vals[i]) { 
+        if (cur_vals[i] >= max_vals[i]) {
           max_vals[i] = cur_vals[i] + bin_width[i]/2.0;
           update_chart = true;
         }
       }
 
       // Until min-dist tracking structure is setup, don't worry about maintaining.
-      if (!is_setup) return;  
+      if (!is_setup) return;
       emp_assert(pos < world.GetSize());
 
       /// Remove org if from the bin we currently have it in.
@@ -474,7 +474,7 @@ namespace emp {
       // These tests only matter BEFORE Setup() is run.
       emp_assert(is_setup || nearest_id.size() == 0);
       emp_assert(is_setup || distance.size() == 0);
- 
+
       // Tests for AFTER Setup() is run.
 
       if (is_setup) {
@@ -502,7 +502,7 @@ namespace emp {
 
   /// This first version will setup a Diverse-Elites world and specify traits to use.
   template <typename ORG>
-  void SetDiverseElites(World<ORG> & world, TraitSet<ORG> traits, size_t world_size) { 
+  void SetDiverseElites(World<ORG> & world, TraitSet<ORG> traits, size_t world_size) {
     world.MarkSynchronous(false);
     world.MarkSpaceStructured(false).MarkPhenoStructured(true);
 


### PR DESCRIPTION
Systematics shouldn't swap `taxon_locations` and `next_taxon_locations` when the world is in asynchronous mode. I added a guard so that code to swap these elements only occurs when the systematics `track_synchronous` is set to true.