### PR TITLE
Fix excessive memory usage caused by default behavior of DataFiles with emscripten

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,4 @@
+[bumpversion]
+current_version = 0.0.2
+commit = True
+tag = True

--- a/source/base/array.h
+++ b/source/base/array.h
@@ -128,7 +128,7 @@ namespace emp {
     array(InputIt first, InputIt last) : base_t(first, last), valid(true) { emp_assert(size() == N); }
     ~array() { valid=false; } // No longer valid when array is deleted.
 
-    operator std::array<T,N>() { 
+    operator std::array<T,N>() {
       std::array<T,N> ar;
       for (size_t i = 0; i < N; i++) ar[i] = base_t::operator[](i);
       return ar;

--- a/source/base/assert.h
+++ b/source/base/assert.h
@@ -23,9 +23,9 @@
  *
  *  When compiled in debug mode (i.e. without the -DNDEBUG flag), this will trigger an assertion
  *  error and print the value of a.
- * 
- * 
- *  @todo: Add emp_assert_warning() for non-terminating assert.  Should be able to disable with 
+ *
+ *
+ *  @todo: Add emp_assert_warning() for non-terminating assert.  Should be able to disable with
  *         a command-line option (-DEMP_NO_WARNINGS)
  */
 

--- a/source/base/errors.h
+++ b/source/base/errors.h
@@ -20,7 +20,7 @@
  *  In general, most of the content of this file is targeted at providing useful tools for library
  *  users; end-users should receive more customized messages and asserts should capture
  *  suposedly "impossible" situations that none-the-less occur in the library itself.
- * 
+ *
  *  NOTES:
  *  - Whenever possible, exceptions should be preferred.  They are more specific than warnings,
  *    but don't halt execution like errors.

--- a/source/data/DataFile.h
+++ b/source/data/DataFile.h
@@ -248,9 +248,9 @@ namespace emp {
     /// Requires that @param node have the data::Stats or data::FullStats modifier.
     template <typename VAL_TYPE, emp::data... MODS>
     size_t AddVariance(DataNode<VAL_TYPE, MODS...> & node, const std::string & key="", const std::string & desc="", const bool & reset=false, const bool & pull=false) {
-      std::function<fun_t> in_fun = [&node, reset, pull](std::ostream & os){ 
+      std::function<fun_t> in_fun = [&node, reset, pull](std::ostream & os){
         if (pull) node.PullData();
-        os << node.GetVariance(); 
+        os << node.GetVariance();
         if (reset) node.Reset();
       };
       return Add(in_fun, key, desc);
@@ -260,10 +260,10 @@ namespace emp {
     /// Requires that @param node have the data::Stats or data::FullStats modifier.
     template <typename VAL_TYPE, emp::data... MODS>
     size_t AddStandardDeviation(DataNode<VAL_TYPE, MODS...> & node, const std::string & key="", const std::string & desc="", const bool & reset=false, const bool & pull=false) {
-      std::function<fun_t> in_fun = [&node, reset, pull](std::ostream & os){ 
+      std::function<fun_t> in_fun = [&node, reset, pull](std::ostream & os){
         if (pull) node.PullData();
-        os << node.GetStandardDeviation(); 
-        if (reset) node.Reset();  
+        os << node.GetStandardDeviation();
+        if (reset) node.Reset();
       };
       return Add(in_fun, key, desc);
     }
@@ -272,10 +272,10 @@ namespace emp {
     /// Requires that @param node have the data::Stats or data::FullStats modifier.
     template <typename VAL_TYPE, emp::data... MODS>
     size_t AddSkew(DataNode<VAL_TYPE, MODS...> & node, const std::string & key="", const std::string & desc="", const bool & reset=false, const bool & pull=false) {
-      std::function<fun_t> in_fun = [&node, reset, pull](std::ostream & os){ 
+      std::function<fun_t> in_fun = [&node, reset, pull](std::ostream & os){
         if (pull) node.PullData();
-        os << node.GetSkew(); 
-        if (reset) node.Reset();  
+        os << node.GetSkew();
+        if (reset) node.Reset();
       };
       return Add(in_fun, key, desc);
     }
@@ -284,9 +284,9 @@ namespace emp {
     /// Requires that @param node have the data::Stats or data::FullStats modifier.
     template <typename VAL_TYPE, emp::data... MODS>
     size_t AddKurtosis(DataNode<VAL_TYPE, MODS...> & node, const std::string & key="", const std::string & desc="", const bool & reset=false, const bool & pull=false) {
-      std::function<fun_t> in_fun = [&node, reset, pull](std::ostream & os){ 
+      std::function<fun_t> in_fun = [&node, reset, pull](std::ostream & os){
         if (pull) node.PullData();
-        os << node.GetKurtosis(); 
+        os << node.GetKurtosis();
         if (reset) node.Reset();
       };
       return Add(in_fun, key, desc);
@@ -306,7 +306,7 @@ namespace emp {
     }
 
 
-    /// Add multiple functions that pull all stats measurements (mean, variance, min, max, 
+    /// Add multiple functions that pull all stats measurements (mean, variance, min, max,
     /// skew, and kurtosis) from the DataNode @param node
     /// Requires that @param node have the data::Stats or data::FullStats modifier.
     /// @param key and @param desc will have the name of the stat appended to the beginning.
@@ -363,7 +363,7 @@ namespace emp {
         using data_t = typename container_t::value_type;
         for (const data_t & d : df->GetCurrentRows()) {
           df->OutputLine(d);
-        }        
+        }
       }
     };
 
@@ -397,12 +397,12 @@ namespace emp {
   ///
   /// Note: CONTAINER type can be a pointer to a container and the
   /// datafile will handle derefeferencing it appropriately.
-  
+
   template <typename CONTAINER>
   class ContainerDataFile : public DataFile {
     protected:
     // The container type cannot be a reference
-    using container_t = typename std::remove_reference<CONTAINER>::type; 
+    using container_t = typename std::remove_reference<CONTAINER>::type;
     using raw_container_t = typename remove_ptr_type<container_t>::type;
     using data_t = typename raw_container_t::value_type;
     using container_fun_t = void(std::ostream &, data_t);
@@ -469,7 +469,7 @@ namespace emp {
           if (i > 0 || keys.size() > 0) *os << line_spacer;
           container_funs[i](*os, d);
         }
-      *os << line_end;  
+      *os << line_end;
     }
 
     /// Run all of the functions and print the results as a new line in the file
@@ -509,7 +509,7 @@ namespace emp {
   /// Convenience function for building a container data file.
   /// @param fun is the function to call to update the container
   template <typename CONTAINER>
-  ContainerDataFile<CONTAINER> MakeContainerDataFile(std::function<CONTAINER(void)> fun, 
+  ContainerDataFile<CONTAINER> MakeContainerDataFile(std::function<CONTAINER(void)> fun,
                                                     const std::string & filename,
                                                     const std::string & b="",
                                                     const std::string & s=",",

--- a/source/data/DataFile.h
+++ b/source/data/DataFile.h
@@ -20,6 +20,7 @@
 #include "../meta/type_traits.h"
 #include "../tools/FunctionSet.h"
 #include "../tools/string_utils.h"
+#include "../tools/NullStream.h"
 
 #include "DataNode.h"
 
@@ -48,7 +49,13 @@ namespace emp {
   public:
     DataFile(const std::string & in_filename,
              const std::string & b="", const std::string & s=",", const std::string & e="\n")
-      : filename(in_filename), os(new std::ofstream(in_filename)), funs(), keys(), descs()
+      : filename(in_filename), os(
+      #ifdef EMSCRIPTEN
+      new emp::NullStream()
+      #else
+      new std::ofstream(in_filename)
+      #endif
+      ), funs(), keys(), descs()
       , timing_fun([](size_t){return true;})
       , line_begin(b), line_spacer(s), line_end(e) { ; }
     DataFile(std::ostream & in_os,

--- a/source/data/DataInterface.h
+++ b/source/data/DataInterface.h
@@ -70,47 +70,47 @@ namespace emp {
     size_t GetResetCount() const { return node->GetResetCount(); }
 
     /// Returns the sum of values added since the last reset.
-    /// Requires that the data::Range or data::FullRange be added to the DataNode 
+    /// Requires that the data::Range or data::FullRange be added to the DataNode
     double GetTotal() const { return node->GetTotal(); }
 
     /// Returns the mean of the values added since the last reset.
-    /// Requires that the data::Range or data::FullRange be added to the DataNode 
+    /// Requires that the data::Range or data::FullRange be added to the DataNode
     double GetMean() const { return node->GetMean(); }
 
     /// Returns the minimum of the values added since the last reset.
-    /// Requires that the data::Range or data::FullRange be added to the DataNode 
+    /// Requires that the data::Range or data::FullRange be added to the DataNode
     double GetMin() const { return node->GetMin(); }
 
     /// Returns the maximum of the values added since the last reset.
-    /// Requires that the data::Range or data::FullRange be added to the DataNode 
+    /// Requires that the data::Range or data::FullRange be added to the DataNode
     double GetMax() const { return node->GetMax(); }
 
     /// Returns the variance of the values added since the last reset.
-    /// Requires that the data::Stats or data::FullStats be added to the DataNode 
+    /// Requires that the data::Stats or data::FullStats be added to the DataNode
     double GetVariance() const { return node->GetVariance(); }
 
     /// Returns the standard deviation of the values added since the last reset.
-    /// Requires that the data::Stats or data::FullStats be added to the DataNode 
+    /// Requires that the data::Stats or data::FullStats be added to the DataNode
     double GetStandardDeviation() const { return node->GetStandardDeviation(); }
 
     /// Returns the skewness of the values added since the last reset.
-    /// Requires that the data::Stats or data::FullStats be added to the DataNode 
+    /// Requires that the data::Stats or data::FullStats be added to the DataNode
     double GetSkew() const { return node->GetSkew(); }
 
     /// Returns the kurtosis of the values added since the last reset.
-    /// Requires that the data::Stats or data::FullStats be added to the DataNode 
+    /// Requires that the data::Stats or data::FullStats be added to the DataNode
     double GetKurtosis() const { return node->GetKurtosis(); }
 
     /// Runs the Pull function for this DataNode and records the resulting values.
     /// Requires that the data::Pull module was added to this DataNode, and that a pull function
     /// was specified.
     void PullData() { node->PullData(); }
-    
+
     /// Reset this node. The exact effects of this depend on the modules that this node has,
     /// but in general it prepares the node to recieve a new set of data.
     void Reset() { node->Reset(); }
 
-    /// Print debug information about this node to @param os. 
+    /// Print debug information about this node to @param os.
     /// Useful for tracking which modifiers are included.
     void PrintDebug(std::ostream & os=std::cout) { node->PrintDebug(os); }
 

--- a/source/data/DataManager.h
+++ b/source/data/DataManager.h
@@ -74,13 +74,13 @@ namespace emp {
 
     // == Operations that forward to DataNode objects ==
 
-    /** Adds data to a node in the DataManager. 
+    /** Adds data to a node in the DataManager.
      *  @param name is the node to add the data to.
-     *  All subsequent arguments are the data to add to that node, 
+     *  All subsequent arguments are the data to add to that node,
      *  and should be of whatever type all of the nodes in this maanger expect.
-     * 
-     * Example: 
-     * 
+     *
+     * Example:
+     *
      * DataManager<int, data::Current, data::Range> my_data_manager;
      * my_data_manager.Add("my_node_name");
      * my_data_manager.AddData("my_node_name", 1, 2, 3, 4, 5);  */
@@ -93,7 +93,7 @@ namespace emp {
     /** Resets all nodes in this manager. For nodes without the data::Archive
      *  attribute, this clears all of their data except current. For nodes with
      *  the data::Archive attribute, this creates a new vector to start storing
-     *  data, retaining the old one in the archive. */ 
+     *  data, retaining the old one in the archive. */
     void ResetAll() {
       for (auto & x : node_map) x.second->Reset();
     }

--- a/source/data/DataNode.h
+++ b/source/data/DataNode.h
@@ -15,7 +15,7 @@
  *   * Clear all data.
  *   * Send data to a stream
  *     (or stats automatically have a stream that, if non-null data is sent to?)
- * 
+ *
  *  @todo: The Archive data node should have Log as a requiste and then copy the current vals into the
  *         archive on reset.  This change will also make it so that the size of the archive correctly
  *         reflects the number of resets.
@@ -112,14 +112,14 @@ namespace emp {
     size_t GetResetCount() const { return 0; }
 
     double GetTotal() const {emp_assert(false, "Calculating total requires a DataNode with the Range or FullRange modifier"); return 0;}
-    double GetMean() const {emp_assert(false, "Calculating mean requires a DataNode with the Range or FullRange modifier"); return 0;}    
+    double GetMean() const {emp_assert(false, "Calculating mean requires a DataNode with the Range or FullRange modifier"); return 0;}
     double GetMin() const {emp_assert(false, "Calculating min requires a DataNode with the Range or FullRange modifier"); return 0;}
     double GetMax() const {emp_assert(false, "Calculating max requires a DataNode with the Range or FullRange modifier"); return 0;}
     double GetVariance() const {emp_assert(false, "Calculating variance requires a DataNode with the Stats or FullStats modifier"); return 0;}
     double GetStandardDeviation() const {emp_assert(false, "Calculating standard deviation requires a DataNode with the Stats or FullStats modifier"); return 0;}
     double GetSkew() const {emp_assert(false, "Calculating skew requires a DataNode with the Stats or FullStats modifier"); return 0;}
     double GetKurtosis() const {emp_assert(false, "Calculating kurtosis requires a DataNode with the Stats or FullStats modifier"); return 0;}
- 
+
     const std::string & GetName() const { return emp::empty_string(); }
     const std::string & GetDescription() const { return emp::empty_string(); }
     const std::string & GetKeyword() const { return emp::empty_string(); }
@@ -159,7 +159,7 @@ namespace emp {
   public:
     DataNodeModule() : cur_val() { ; }
 
-    /// Return the current (most recently added) value 
+    /// Return the current (most recently added) value
     const VAL_TYPE & GetCurrent() const { return cur_val; }
 
     /// Add @param val to this DataNode
@@ -231,7 +231,7 @@ namespace emp {
     /// Get a vector of all data added since the last reset
     const emp::vector<VAL_TYPE> & GetData() const { return val_set; }
 
-    /// Add @param val to this DataNode 
+    /// Add @param val to this DataNode
     void AddDatum(const VAL_TYPE & val) {
       val_set.push_back(val);
       parent_t::AddDatum(val);
@@ -274,7 +274,7 @@ namespace emp {
 
     /// Get a vector of all data that was added during the @param update 'th interval between resets.
     const emp::vector<VAL_TYPE> & GetData(size_t update) const { return archive[update]; }
-    
+
     /// Get a vector of all data that has been added since the last reset
     const emp::vector<VAL_TYPE> & GetData() const { return val_set; }
 
@@ -299,7 +299,7 @@ namespace emp {
   };
 
   /// == data::Range ==
-  /// This module allows this DataNode to store information (min, max, mean, count, and total) about 
+  /// This module allows this DataNode to store information (min, max, mean, count, and total) about
   /// the distribution of the values that have been added since the last call to Reset().
   template <typename VAL_TYPE, emp::data... MODS>
   class DataNodeModule<VAL_TYPE, data::Range, MODS...> : public DataNodeModule<VAL_TYPE, MODS...> {
@@ -321,10 +321,10 @@ namespace emp {
 
     /// Get the mean of all values added to this DataNode since the last reset
     double GetMean() const { return total / (double) base_t::val_count; }
-    
+
     /// Get the min of all values added to this DataNode since the last reset
     double GetMin() const { return min; }
-    
+
     /// Get the max of all values added to this DataNode since the last reset
     double GetMax() const { return max; }
 
@@ -336,7 +336,7 @@ namespace emp {
       parent_t::AddDatum(val);
     }
 
-    /// Reset DataNode, setting the running calucluations of total, min, mean, and max to 0 
+    /// Reset DataNode, setting the running calucluations of total, min, mean, and max to 0
     void Reset() {
       total = 0.0;
       min = 0.0;
@@ -383,13 +383,13 @@ namespace emp {
 
     /// Get the minimum of all values added to this DataNode since the last reset
     double GetMin() const { return min; }
-  
+
     /// Get the maximum of all values added to this DataNode since the last reset
     double GetMax() const { return max; }
 
     /// Get the sum of all values added to this DataNode during the @param update specified.
     double GetTotal(size_t update) const { return total_vals[update]; }
-    
+
     /// Get the mean of all values added to this DataNode during the @param update specified.
     double GetMean(size_t update) const { return total_vals[update] / (double) num_vals[update]; }
 
@@ -424,7 +424,7 @@ namespace emp {
   /// == data::Stats ==
   /// Note: These statistics are calculated with the assumption that the data this node has
   /// recieved is the entire population of measurements we're interested in, not a sample.
-  /// 
+  ///
   /// Note 2: Kurtosis is calculated using Snedecor and Cochran (1967)'s formula. A perfect normal
   /// distribution has a kurtosis of 0.
 
@@ -447,7 +447,7 @@ namespace emp {
     using parent_t::total;
     using parent_t::min;
     using parent_t::max;
-    
+
   public:
     DataNodeModule() : M2(0), M3(0), M4(0) { ; }
 
@@ -455,11 +455,11 @@ namespace emp {
 
     /// Get the variance (squared deviation from the mean) of values added since the last reset
     double GetVariance() const {return M2/(double)val_count;}
-    
+
     /// Get the standard deviation of values added since the last reset
     double GetStandardDeviation() const {return sqrt(GetVariance());}
-    
-    /// Get the skewness of values added since the last reset. This measurement tells you about 
+
+    /// Get the skewness of values added since the last reset. This measurement tells you about
     /// the shape of the distribution. For a unimodal distribution, negative skew means that the
     /// distribution has a longer/thicker tail to the left. Positive skew means that ths distribution
     /// has a longer/thicker tail to the right.
@@ -467,7 +467,7 @@ namespace emp {
 
     /// Get the kurtosis of the values added since the last reset. This is another measurement that
     /// describes the shape of the distribution. High kurtosis means that there is more data in the
-    /// tails of the distribution (i.e. the tails are "heavier"), whereas low kurtosis means that 
+    /// tails of the distribution (i.e. the tails are "heavier"), whereas low kurtosis means that
     /// there is less data in the tails. We use Snedecor and Cochran (1967)'s formula to calculate
     /// kurtosis. Under this formula, a normal distribution has kurtosis of 0.
     double GetKurtosis() const {return double(val_count)*M4 / (M2*M2) - 3.0;}
@@ -511,7 +511,7 @@ namespace emp {
   protected:
     VAL_TYPE offset;              ///< Min value in first bin; others are offset by this much.
     VAL_TYPE width;               ///< How wide is the overall histogram?
-    IndexMap bins;                ///< Map of values to which bin they fall in. 
+    IndexMap bins;                ///< Map of values to which bin they fall in.
     emp::vector<size_t> counts;   ///< Counts in each bin.
 
     using this_t = DataNodeModule<VAL_TYPE, data::Histogram, MODS...>;
@@ -535,7 +535,7 @@ namespace emp {
     size_t GetHistCount(size_t bin_id) const { return counts[bin_id]; }
 
     /// Return the width of the @param bin_id 'th bin of the histogram
-    double GetHistWidth(size_t bin_id) const { return bins[bin_id]; } //width / (double) counts.size(); } 
+    double GetHistWidth(size_t bin_id) const { return bins[bin_id]; } //width / (double) counts.size(); }
 
     /// Return a vector containing the count of items in each bin of the histogram
     const emp::vector<size_t> & GetHistCounts() const { return counts; }
@@ -691,21 +691,21 @@ namespace emp {
 
   // Shortcuts for common types of data nodes...
 
-  /** A node that stores data about the most recent value it recieved, as well as the 
+  /** A node that stores data about the most recent value it recieved, as well as the
    * distribution (min, max, count, total, and mean) of values it has recieved since
    * the last reset. It also allows you to give it a name, description, and keyword.*/
   template <typename T, emp::data... MODS>
   using DataMonitor = DataNode<T, data::Current, data::Info, data::Range, data::Stats, MODS...>;
 
-  /** A node that stores data about the most recent value it recieved, as well as all 
-   * values it has recieved since the last reset. It also allows you to give it a name, 
+  /** A node that stores data about the most recent value it recieved, as well as all
+   * values it has recieved since the last reset. It also allows you to give it a name,
    * description, and keyword.*/
   template <typename T, emp::data... MODS>
   using DataLog = DataNode<T, data::Current, data::Info, data::Log, MODS...>;
-  
+
   /** A node that stores all data it recieves in an archive (vector of vectors). The inner
-   * vectors are groups of data that were recieved between resets. This node also keeps 
-   * a record of the min, max, count, and total of each vector, so you don't have to 
+   * vectors are groups of data that were recieved between resets. This node also keeps
+   * a record of the min, max, count, and total of each vector, so you don't have to
    * recalculate it later. Additionally, it allows you to give it a name, description,
    * and keyword.*/
   template <typename T, emp::data... MODS>

--- a/source/tools/NullStream.h
+++ b/source/tools/NullStream.h
@@ -1,0 +1,36 @@
+/**
+ *  @note This file is part of Empirical, https://github.com/devosoft/Empirical
+ *  @copyright Copyright (C) Michigan State University, MIT Software license; see doc/LICENSE.md
+ *  @date 2018
+ *
+ *  @file  NullStream.h
+ *  @brief A handy no-operation output stream.
+ *  @note Status: BETA
+ */
+
+#ifndef EMP_NULLSTREAM_H
+#define EMP_NULLSTREAM_H
+
+#include <iostream>
+
+namespace emp {
+
+  /// A no-operation buffer class
+  class NullBuffer : public std::streambuf {
+    public:
+      int overflow(int c) {
+        return c;
+      }
+  };
+
+  /// A no-operation output stream class
+  class NullStream : public std::ostream {
+    public:
+      NullStream() : std::ostream(&m_sb) { ; }
+    private:
+      NullBuffer m_sb;
+  };
+
+}
+
+#endif

--- a/tests/test_tools.cc
+++ b/tests/test_tools.cc
@@ -39,6 +39,7 @@
 #include "tools/math.h"
 #include "tools/mem_track.h"
 #include "tools/memo_function.h"
+#include "tools/NullStream.h"
 #include "tools/sequence_utils.h"
 // #include "tools/serialize.h"
 #include "tools/set_utils.h"
@@ -779,6 +780,16 @@ TEST_CASE("Test NFA", "[tools]")
   REQUIRE(state2.GetSize() == 7);
 }
 
+
+TEST_CASE("Test NullStream", "[tools]")
+{
+  emp::NullStream ns;
+  ns << "abcdefg";
+  ns << std::endl;
+  ns << 123;
+  ns << 123.456;
+  ns.flush();
+}
 
 
 TEST_CASE("Test random", "[tools]")


### PR DESCRIPTION
* Add handy NullStream class to tools
   * This is a no-op output stream.
   * Unit tests included. :smile_cat: 
* Use handy NullStream class to patch excessive memory use for DataFiles compiled with emscripten
* Add `.bumpversion.cfg` file
  * This will let us bump versions via `bumpversion patch`/`bumpversion minor`/`bumpversion major` to reach versions `v0.0.3`, `v0.1.0`, or `v1.0.0` respectively using the Bumpversion tool.
  * Specifically, Bumpversion will make a commit with the version change reflected in .bumpversion.cfg and then tag a release for us. :stars: 
  * [Example commit](https://github.com/mmore500/dishtiny/commit/a01234ef12208175c29d86441e8e9ba96b545606) with corresponding [example tag](https://github.com/mmore500/dishtiny/releases/tag/v0.3.0)
  * More info here: [https://pypi.org/project/bumpversion/](https://pypi.org/project/bumpversion/)