### PR TITLE
Implement and test math tools

### DIFF
--- a/source/tools/math.h
+++ b/source/tools/math.h
@@ -18,6 +18,7 @@
 
 #include "../base/assert.h"
 #include "../meta/reflection.h"
+#include "Random.h"
 #include "const.h"
 
 namespace emp {
@@ -39,6 +40,69 @@ namespace emp {
 
   /// Find the absolute value for any variable.
   template <typename T> constexpr T Abs(T in) { return (in > 0) ? in : (-in); }
+
+  /// Divide one integer by another, rounding towards minus infinity.
+  int inline FloorDivide(int dividend, int divisor) {
+    int q = dividend/divisor;
+    int r = dividend%divisor;
+    if ((r!=0) && ((r<0) != (divisor<0))) --q;
+    return q;
+  }
+
+  /// Default integer division is truncated, not rounded.
+  /// Round the division result instead of truncating it.
+  /// Rounding ties (i.e., result % divisor == 0.5) are rounded up.
+  int inline RoundedDivide(int dividend, int divisor) {
+    //TODO add emp_assert to check for overflow
+    emp_assert(divisor != 0);
+    // adding divisor/2 to dividend
+    // is equivalent to adding 1/2 to the result
+    return FloorDivide(dividend + divisor / 2, divisor);
+  }
+
+  /// Default integer division is truncated, not rounded.
+  /// Round the division result instead of truncating it.
+  /// Rounding ties (i.e., result % divisor == 0.5)
+  /// will be rounded up.
+  size_t inline RoundedDivide(size_t dividend, size_t divisor) {
+    //TODO add emp_assert to check for overflow
+    emp_assert(divisor != 0);
+    // adding divisor/2 to dividend
+    // is equivalent to adding 1/2 to the result
+    return (dividend + divisor / 2) / divisor;
+  }
+
+  /// Regular integer division is truncated, not rounded.
+  /// Round the division result instead of truncating it.
+  /// Rounding ties (i.e., result % divisor == 0.5) are broken
+  /// by coin toss.
+  int inline UnbiasedDivide(int dividend, int divisor, emp::Random& r) {
+    //TODO add emp_assert to check for overflow
+    int res = RoundedDivide(dividend, divisor);
+    // if dividend/divisor % 1 == 0.5...
+    if (Abs(dividend % divisor) * 2 == Abs(divisor)) {
+      // ... by default, the result is rounded up;
+      // with 1/2 probability round down instead
+      res -= r.GetInt(2);
+    }
+    return res;
+  }
+
+  /// Regular integer division is truncated, not rounded.
+  /// Round the division result instead of truncating it.
+  /// Rounding ties (i.e., result % divisor == 0.5) are broken
+  /// by coin toss.
+  inline size_t UnbiasedDivide(size_t dividend, size_t divisor, emp::Random& r) {
+    //TODO add emp_assert to check for overflow
+    size_t res = RoundedDivide(dividend, divisor);
+    // if dividend/divisor % 1 == 0.5...
+    if ((dividend % divisor) * 2 == divisor) {
+      // ... by default, the result is rounded up;
+      // with 1/2 probability round down instead
+      res -= r.GetInt(2);
+    }
+    return res;
+  }
 
   /// Run both min and max on a value to put it into a desired range.
   template <typename TYPE> constexpr TYPE ToRange(const TYPE & value, const TYPE & in_min, const TYPE & in_max) {
@@ -227,7 +291,6 @@ namespace emp {
     }
     return *max_found;
   }
-
 
 }
 

--- a/source/tools/math.h
+++ b/source/tools/math.h
@@ -38,6 +38,11 @@ namespace emp {
     return (remain < 0.0) ? (remain + mod_val) : remain;
   }
 
+  /// Calculate the sign (i.e., +1, -1, or 0) of a value.
+  template <typename T> inline int Sgn(T val) {
+    return (T(0) < val) - (val < T(0));
+  }
+
   /// Find the absolute value for any variable.
   template <typename T> constexpr T Abs(T in) { return (in > 0) ? in : (-in); }
 

--- a/tests/test_tools.cc
+++ b/tests/test_tools.cc
@@ -14,6 +14,9 @@
 #include <sstream>
 #include <string>
 #include <deque>
+#include <algorithm>
+
+#include "data/DataNode.h"
 
 #include "tools/Binomial.h"
 #include "tools/BitMatrix.h"
@@ -711,6 +714,185 @@ TEST_CASE("Test math", "[tools]")
   REQUIRE(emp::Max(5,10) == 10);
   REQUIRE(emp::Max(10,5) == 10);
   REQUIRE(emp::Max(40,30,20,10,45,15,25,35) == 45);
+
+  REQUIRE(emp::FloorDivide(0,4) == 0);
+  REQUIRE(emp::FloorDivide(1,4) == 0);
+  REQUIRE(emp::FloorDivide(2,4) == 0);
+  REQUIRE(emp::FloorDivide(3,4) == 0);
+  REQUIRE(emp::FloorDivide(4,4) == 1);
+  REQUIRE(emp::FloorDivide(6,4) == 1);
+  REQUIRE(emp::FloorDivide(5,3) == 1);
+  REQUIRE(emp::FloorDivide(6,3) == 2);
+  REQUIRE(emp::FloorDivide(7,3) == 2);
+
+  REQUIRE(emp::FloorDivide((size_t)0,(size_t)4) == 0);
+  REQUIRE(emp::FloorDivide((size_t)1,(size_t)4) == 0);
+  REQUIRE(emp::FloorDivide((size_t)2,(size_t)4) == 0);
+  REQUIRE(emp::FloorDivide((size_t)3,(size_t)4) == 0);
+  REQUIRE(emp::FloorDivide((size_t)4,(size_t)4) == 1);
+  REQUIRE(emp::FloorDivide((size_t)6,(size_t)4) == 1);
+  REQUIRE(emp::FloorDivide((size_t)5,(size_t)3) == 1);
+  REQUIRE(emp::FloorDivide((size_t)6,(size_t)3) == 2);
+  REQUIRE(emp::FloorDivide((size_t)7,(size_t)3) == 2);
+
+  REQUIRE(emp::FloorDivide(-1,4) == -1);
+  REQUIRE(emp::FloorDivide(-2,4) == -1);
+  REQUIRE(emp::FloorDivide(-3,4) == -1);
+  REQUIRE(emp::FloorDivide(-4,4) == -1);
+  REQUIRE(emp::FloorDivide(-6,4) == -2);
+  REQUIRE(emp::FloorDivide(-5,3) == -2);
+  REQUIRE(emp::FloorDivide(-6,3) == -2);
+  REQUIRE(emp::FloorDivide(-7,3) == -3);
+
+  REQUIRE(emp::FloorDivide(0,-4) == 0);
+  REQUIRE(emp::FloorDivide(1,-4) == -1);
+  REQUIRE(emp::FloorDivide(2,-4) == -1);
+  REQUIRE(emp::FloorDivide(3,-4) == -1);
+  REQUIRE(emp::FloorDivide(4,-4) == -1);
+  REQUIRE(emp::FloorDivide(6,-4) == -2);
+  REQUIRE(emp::FloorDivide(5,-3) == -2);
+  REQUIRE(emp::FloorDivide(6,-3) == -2);
+  REQUIRE(emp::FloorDivide(7,-3) == -3);
+
+  REQUIRE(emp::FloorDivide(-1,-4) == 0);
+  REQUIRE(emp::FloorDivide(-2,-4) == 0);
+  REQUIRE(emp::FloorDivide(-3,-4) == 0);
+  REQUIRE(emp::FloorDivide(-4,-4) == 1);
+  REQUIRE(emp::FloorDivide(-6,-4) == 1);
+  REQUIRE(emp::FloorDivide(-5,-3) == 1);
+  REQUIRE(emp::FloorDivide(-6,-3) == 2);
+  REQUIRE(emp::FloorDivide(-7,-3) == 2);
+
+  REQUIRE(emp::RoundedDivide(0,4) == 0);
+  REQUIRE(emp::RoundedDivide(1,4) == 0);
+  REQUIRE(emp::RoundedDivide(2,4) == 1);
+  REQUIRE(emp::RoundedDivide(3,4) == 1);
+  REQUIRE(emp::RoundedDivide(4,4) == 1);
+  REQUIRE(emp::RoundedDivide(6,4) == 2);
+  REQUIRE(emp::RoundedDivide(5,3) == 2);
+  REQUIRE(emp::RoundedDivide(6,3) == 2);
+  REQUIRE(emp::RoundedDivide(7,3) == 2);
+
+  REQUIRE(emp::RoundedDivide((size_t)0,(size_t)4) == 0);
+  REQUIRE(emp::RoundedDivide((size_t)1,(size_t)4) == 0);
+  REQUIRE(emp::RoundedDivide((size_t)2,(size_t)4) == 1);
+  REQUIRE(emp::RoundedDivide((size_t)3,(size_t)4) == 1);
+  REQUIRE(emp::RoundedDivide((size_t)4,(size_t)4) == 1);
+  REQUIRE(emp::RoundedDivide((size_t)6,(size_t)4) == 2);
+  REQUIRE(emp::RoundedDivide((size_t)5,(size_t)3) == 2);
+  REQUIRE(emp::RoundedDivide((size_t)6,(size_t)3) == 2);
+  REQUIRE(emp::RoundedDivide((size_t)7,(size_t)3) == 2);
+
+  REQUIRE(emp::RoundedDivide(-1,4) == 0);
+  REQUIRE(emp::RoundedDivide(-2,4) == 0);
+  REQUIRE(emp::RoundedDivide(-3,4) == -1);
+  REQUIRE(emp::RoundedDivide(-4,4) == -1);
+  REQUIRE(emp::RoundedDivide(-6,4) == -1);
+  REQUIRE(emp::RoundedDivide(-5,3) == -2);
+  REQUIRE(emp::RoundedDivide(-6,3) == -2);
+  REQUIRE(emp::RoundedDivide(-7,3) == -2);
+
+  REQUIRE(emp::RoundedDivide(0,-4) == 0);
+  REQUIRE(emp::RoundedDivide(1,-4) == 0);
+  REQUIRE(emp::RoundedDivide(2,-4) == 0);
+  REQUIRE(emp::RoundedDivide(3,-4) == -1);
+  REQUIRE(emp::RoundedDivide(4,-4) == -1);
+  REQUIRE(emp::RoundedDivide(6,-4) == -1);
+  REQUIRE(emp::RoundedDivide(5,-3) == -2);
+  REQUIRE(emp::RoundedDivide(6,-3) == -2);
+  REQUIRE(emp::RoundedDivide(7,-3) == -2);
+
+  REQUIRE(emp::RoundedDivide(-1,-4) == 0);
+  REQUIRE(emp::RoundedDivide(-2,-4) == 1);
+  REQUIRE(emp::RoundedDivide(-3,-4) == 1);
+  REQUIRE(emp::RoundedDivide(-4,-4) == 1);
+  REQUIRE(emp::RoundedDivide(-6,-4) == 2);
+  REQUIRE(emp::RoundedDivide(-5,-3) == 2);
+  REQUIRE(emp::RoundedDivide(-6,-3) == 2);
+  REQUIRE(emp::RoundedDivide(-7,-3) == 2);
+
+  REQUIRE(emp::RoundedDivide((size_t)0,(size_t)4) == 0);
+  REQUIRE(emp::RoundedDivide((size_t)1,(size_t)4) == 0);
+  REQUIRE(emp::RoundedDivide((size_t)2,(size_t)4) == 1);
+  REQUIRE(emp::RoundedDivide((size_t)3,(size_t)4) == 1);
+  REQUIRE(emp::RoundedDivide((size_t)4,(size_t)4) == 1);
+  REQUIRE(emp::RoundedDivide((size_t)6,(size_t)4) == 2);
+  REQUIRE(emp::RoundedDivide((size_t)5,(size_t)3) == 2);
+  REQUIRE(emp::RoundedDivide((size_t)6,(size_t)3) == 2);
+  REQUIRE(emp::RoundedDivide((size_t)7,(size_t)3) == 2);
+
+  auto MeanUnbiasedDivide = [](int dividend, int divisor, size_t rc){
+    emp::Random r = emp::Random(1);
+    emp::DataNode<double, emp::data::Current, emp::data::Range, emp::data::Log> data;
+    for(size_t i=0;i<rc;++i) data.Add(emp::UnbiasedDivide(dividend,divisor,r));
+    return data.GetMean();
+  };
+
+  REQUIRE(MeanUnbiasedDivide(0,4,100) == 0);
+  REQUIRE(MeanUnbiasedDivide(1,4,100) == 0);
+  REQUIRE(MeanUnbiasedDivide(2,4,100) > 0);
+  REQUIRE(MeanUnbiasedDivide(2,4,100) < 1);
+  REQUIRE(MeanUnbiasedDivide(3,4,100) == 1);
+  REQUIRE(MeanUnbiasedDivide(4,4,100) == 1);
+  REQUIRE(MeanUnbiasedDivide(6,4,100) > 1);
+  REQUIRE(MeanUnbiasedDivide(6,4,100) < 2);
+  REQUIRE(MeanUnbiasedDivide(5,3,100) == 2);
+  REQUIRE(MeanUnbiasedDivide(6,3,100) == 2);
+  REQUIRE(MeanUnbiasedDivide(7,3,100) == 2);
+
+  REQUIRE(MeanUnbiasedDivide(-1,4,100) == 0);
+  REQUIRE(MeanUnbiasedDivide(-2,4,100) < 0);
+  REQUIRE(MeanUnbiasedDivide(-2,4,100) > -1);
+  REQUIRE(MeanUnbiasedDivide(-3,4,100) == -1);
+  REQUIRE(MeanUnbiasedDivide(-4,4,100) == -1);
+  REQUIRE(MeanUnbiasedDivide(-6,4,100) < -1);
+  REQUIRE(MeanUnbiasedDivide(-6,4,100) > -2);
+  REQUIRE(MeanUnbiasedDivide(-5,3,100) == -2);
+  REQUIRE(MeanUnbiasedDivide(-6,3,100) == -2);
+  REQUIRE(MeanUnbiasedDivide(-7,3,100) == -2);
+
+  REQUIRE(MeanUnbiasedDivide(0,-4,100) == 0);
+  REQUIRE(MeanUnbiasedDivide(1,-4,100) == 0);
+  REQUIRE(MeanUnbiasedDivide(2,-4,100) < 0);
+  REQUIRE(MeanUnbiasedDivide(2,-4,100) > -1);
+  REQUIRE(MeanUnbiasedDivide(3,-4,100) == -1);
+  REQUIRE(MeanUnbiasedDivide(4,-4,100) == -1);
+  REQUIRE(MeanUnbiasedDivide(6,-4,100) < -1);
+  REQUIRE(MeanUnbiasedDivide(6,-4,100) > -2);
+  REQUIRE(MeanUnbiasedDivide(5,-3,100) == -2);
+  REQUIRE(MeanUnbiasedDivide(6,-3,100) == -2);
+  REQUIRE(MeanUnbiasedDivide(7,-3,100) == -2);
+
+  REQUIRE(MeanUnbiasedDivide(-1,-4,100) == 0);
+  REQUIRE(MeanUnbiasedDivide(-2,-4,100) > 0);
+  REQUIRE(MeanUnbiasedDivide(-2,-4,100) < 1);
+  REQUIRE(MeanUnbiasedDivide(-3,-4,100) == 1);
+  REQUIRE(MeanUnbiasedDivide(-4,-4,100) == 1);
+  REQUIRE(MeanUnbiasedDivide(-6,-4,100) > 1);
+  REQUIRE(MeanUnbiasedDivide(-6,-4,100) < 2);
+  REQUIRE(MeanUnbiasedDivide(-5,-3,100) == 2);
+  REQUIRE(MeanUnbiasedDivide(-6,-3,100) == 2);
+  REQUIRE(MeanUnbiasedDivide(-7,-3,100) == 2);
+
+  auto SztMeanUnbiasedDivide = [](size_t dividend, size_t divisor, size_t rc){
+    emp::Random r = emp::Random(1);
+    emp::DataNode<double, emp::data::Current, emp::data::Range, emp::data::Log> data;
+    for(size_t i=0;i<rc;++i) data.Add(emp::UnbiasedDivide(dividend,divisor,r));
+    return data.GetMean();
+  };
+
+  REQUIRE(SztMeanUnbiasedDivide((size_t)0,(size_t)4,100) == 0);
+  REQUIRE(SztMeanUnbiasedDivide((size_t)1,(size_t)4,100) == 0);
+  REQUIRE(SztMeanUnbiasedDivide((size_t)2,(size_t)4,100) > 0);
+  REQUIRE(SztMeanUnbiasedDivide((size_t)2,(size_t)4,100) < 1);
+  REQUIRE(SztMeanUnbiasedDivide((size_t)3,(size_t)4,100) == 1);
+  REQUIRE(SztMeanUnbiasedDivide((size_t)4,(size_t)4,100) == 1);
+  REQUIRE(SztMeanUnbiasedDivide((size_t)6,(size_t)4,100) > 1);
+  REQUIRE(SztMeanUnbiasedDivide((size_t)6,(size_t)4,100) < 2);
+  REQUIRE(SztMeanUnbiasedDivide((size_t)5,(size_t)3,100) == 2);
+  REQUIRE(SztMeanUnbiasedDivide((size_t)6,(size_t)3,100) == 2);
+  REQUIRE(SztMeanUnbiasedDivide((size_t)7,(size_t)3,100) == 2);
+
 }
 
 

--- a/tests/test_tools.cc
+++ b/tests/test_tools.cc
@@ -893,6 +893,32 @@ TEST_CASE("Test math", "[tools]")
   REQUIRE(SztMeanUnbiasedDivide((size_t)6,(size_t)3,100) == 2);
   REQUIRE(SztMeanUnbiasedDivide((size_t)7,(size_t)3,100) == 2);
 
+  REQUIRE(emp::Sgn(1) == 1);
+  REQUIRE(emp::Sgn(2) == 1);
+  REQUIRE(emp::Sgn(3) == 1);
+  REQUIRE(emp::Sgn(102) == 1);
+  REQUIRE(emp::Sgn(0) == 0);
+  REQUIRE(emp::Sgn(-1) == -1);
+  REQUIRE(emp::Sgn(-2) == -1);
+  REQUIRE(emp::Sgn(-3) == -1);
+  REQUIRE(emp::Sgn(-102) == -1);
+
+  REQUIRE(emp::Sgn((size_t)1) == 1);
+  REQUIRE(emp::Sgn((size_t)2) == 1);
+  REQUIRE(emp::Sgn((size_t)3) == 1);
+  REQUIRE(emp::Sgn((size_t)102) == 1);
+  REQUIRE(emp::Sgn((size_t)0) == 0);
+
+  REQUIRE(emp::Sgn(1.0) == 1);
+  REQUIRE(emp::Sgn(2.1) == 1);
+  REQUIRE(emp::Sgn(3.0) == 1);
+  REQUIRE(emp::Sgn(102.5) == 1);
+  REQUIRE(emp::Sgn(0.0) == 0);
+  REQUIRE(emp::Sgn(-1.0) == -1);
+  REQUIRE(emp::Sgn(-2.1) == -1);
+  REQUIRE(emp::Sgn(-3.0) == -1);
+  REQUIRE(emp::Sgn(-102.5) == -1);
+
 }
 
 


### PR DESCRIPTION
In `tools/math.h` I implemented and tested
* `FloorDivide`, which performs integer division and always rounds down (C++ division behavior is to truncate which means rounding up for negative results)
* `RoundedDivide`, which performs integer division and rounds towards nearest integer and always rounds up on ties
* `UnbiasedDivide`, which performs integer division and, on ties, rounds up or down based on a emp::Random coin toss
* `Sgn`, which calculates the sign of a value (i.e., -1, 0, or 1)

For the Divide functions, integer (slower) and size_t (faster) versions are implemented.