### PR TITLE
Implement and test Szudzik hash

### DIFF
--- a/source/tools/hash_utils.h
+++ b/source/tools/hash_utils.h
@@ -1,0 +1,27 @@
+/**
+ *  @note This file is part of Empirical, https://github.com/devosoft/Empirical
+ *  @copyright Copyright (C) Michigan State University, MIT Software license; see doc/LICENSE.md
+ *  @date 2019
+ *
+ *  @file  hash_utils.h
+ *  @brief This file provides tools for hashing values.
+ *  @note Status: BETA
+ */
+
+#ifndef EMP_HASH_UTILS_H
+#define EMP_HASH_UTILS_H
+
+#include <type_traits>
+
+namespace emp {
+
+  /// generate a unique long from a pair of ints
+  uint64_t szudzik_hash(uint32_t a_, uint32_t b_)
+  {
+    uint64_t a = a_, b = b_;
+    return a >= b ? a * a + a + b : a + b * b;
+  }
+
+}
+
+#endif

--- a/tests/test_tools.cc
+++ b/tests/test_tools.cc
@@ -15,6 +15,8 @@
 #include <string>
 #include <deque>
 #include <algorithm>
+#include <climits>
+#include <unordered_set>
 
 #include "data/DataNode.h"
 
@@ -36,6 +38,7 @@
 #include "tools/flex_function.h"
 #include "tools/functions.h"
 #include "tools/graph_utils.h"
+#include "tools/hash_utils.h"
 //#include "tools/grid.h"
 #include "tools/info_theory.h"
 #include "tools/lexer_utils.h"
@@ -525,6 +528,74 @@ TEST_CASE("Test Graph utils", "[tools]")
   emp::Graph graph( emp::build_graph_grid(5, 4, random) );
 
   // graph.PrintSym();
+}
+
+// // TODO: add asserts
+// emp::Random grand;
+TEST_CASE("Test hash_utils", "[tools]")
+{
+
+  REQUIRE(emp::szudzik_hash((uint32_t)0, (uint32_t)0) == (uint64_t)0);
+
+  REQUIRE(emp::szudzik_hash((uint32_t)0, (uint32_t)1) == (uint64_t)1);
+
+  REQUIRE(emp::szudzik_hash((uint32_t)1, (uint32_t)0) == (uint64_t)2);
+  REQUIRE(emp::szudzik_hash((uint32_t)1, (uint32_t)1) == (uint64_t)3);
+
+  REQUIRE(emp::szudzik_hash((uint32_t)0, (uint32_t)2) == (uint64_t)4);
+  REQUIRE(emp::szudzik_hash((uint32_t)1, (uint32_t)2) == (uint64_t)5);
+
+  REQUIRE(emp::szudzik_hash((uint32_t)2, (uint32_t)0) == (uint64_t)6);
+  REQUIRE(emp::szudzik_hash((uint32_t)2, (uint32_t)1) == (uint64_t)7);
+  REQUIRE(emp::szudzik_hash((uint32_t)2, (uint32_t)2) == (uint64_t)8);
+
+  REQUIRE(emp::szudzik_hash((uint32_t)0, (uint32_t)3) == (uint64_t)9);
+  REQUIRE(emp::szudzik_hash((uint32_t)1, (uint32_t)3) == (uint64_t)10);
+  REQUIRE(emp::szudzik_hash((uint32_t)2, (uint32_t)3) == (uint64_t)11);
+
+  REQUIRE(emp::szudzik_hash((uint32_t)3, (uint32_t)0) == (uint64_t)12);
+  REQUIRE(emp::szudzik_hash((uint32_t)3, (uint32_t)1) == (uint64_t)13);
+  REQUIRE(emp::szudzik_hash((uint32_t)3, (uint32_t)2) == (uint64_t)14);
+  REQUIRE(emp::szudzik_hash((uint32_t)3, (uint32_t)3) == (uint64_t)15);
+
+
+  REQUIRE(emp::szudzik_hash((uint32_t)0, (uint32_t)0) == (uint64_t)0);
+
+  REQUIRE(emp::szudzik_hash((uint32_t)0, (uint32_t)1) == (uint64_t)1);
+
+  REQUIRE(emp::szudzik_hash((uint32_t)1, (uint32_t)0) == (uint64_t)2);
+  REQUIRE(emp::szudzik_hash((uint32_t)1, (uint32_t)1) == (uint64_t)3);
+
+  REQUIRE(emp::szudzik_hash((uint32_t)0, (uint32_t)2) == (uint64_t)4);
+  REQUIRE(emp::szudzik_hash((uint32_t)1, (uint32_t)2) == (uint64_t)5);
+
+  REQUIRE(emp::szudzik_hash((uint32_t)2, (uint32_t)0) == (uint64_t)6);
+  REQUIRE(emp::szudzik_hash((uint32_t)2, (uint32_t)1) == (uint64_t)7);
+  REQUIRE(emp::szudzik_hash((uint32_t)2, (uint32_t)2) == (uint64_t)8);
+
+  REQUIRE(emp::szudzik_hash((uint32_t)0, (uint32_t)3) == (uint64_t)9);
+  REQUIRE(emp::szudzik_hash((uint32_t)1, (uint32_t)3) == (uint64_t)10);
+  REQUIRE(emp::szudzik_hash((uint32_t)2, (uint32_t)3) == (uint64_t)11);
+
+  REQUIRE(emp::szudzik_hash((uint32_t)3, (uint32_t)0) == (uint64_t)12);
+  REQUIRE(emp::szudzik_hash((uint32_t)3, (uint32_t)1) == (uint64_t)13);
+  REQUIRE(emp::szudzik_hash((uint32_t)3, (uint32_t)2) == (uint64_t)14);
+  REQUIRE(emp::szudzik_hash((uint32_t)3, (uint32_t)3) == (uint64_t)15);
+
+  emp::vector<uint64_t> hash_vec;
+
+  for(uint32_t i = 0; i < 10; ++i) {
+    for(uint32_t j = 0; j < 10; ++j) {
+      for(uint32_t s : { 0, 100, 100000 }) {
+        hash_vec.push_back(emp::szudzik_hash(s+i,s+j));
+      }
+    }
+  }
+
+  std::unordered_set<uint64_t> hash_set(hash_vec.begin(), hash_vec.end());
+
+  REQUIRE(hash_vec.size() == hash_set.size());
+
 }
 
 


### PR DESCRIPTION
I added a new header file `hash_utils.h` to `source/tools` and wrote the function `uint64_t emp::szudzik_hash(uint32_t a, uint32_t b)` which takes two numbers `a` and `b` and returns a third number that is unique across all possible combinations of `a` and `b` using the method pictured below.

![image](https://user-images.githubusercontent.com/10763333/51577262-392a4300-1e87-11e9-97db-d644383d14db.png)

This is method preferable to just concatenating the bits of `a` and `b` because (for the range of values that don't overflow `a` and `b`) the result won't change if the types of `a` and `b` (i.e., the constituent numbers of bits in `a` and `b`) do change.

Code was adapted from [https://stackoverflow.com/questions/919612/mapping-two-integers-to-one-in-a-unique-and-deterministic-way](https://stackoverflow.com/questions/919612/mapping-two-integers-to-one-in-a-unique-and-deterministic-way).

I played around with some template metaprogramming to try to make the function template correctly onto all possible input types (e.g., return `uint16_t` for `uint8_t` input, return `uint32_t` for `uint16_t` input, return `uint64_t` for `uint32_t` input, ... and only allow unsigned types)  but I couldn't quite get it compiling. Of course, we could always just manually define  functions  for each of the three type combinations separately, too.

Also, wrote tests for the new code.