### PR TITLE
Write and test uint64_t generator

### DIFF
--- a/source/tools/Random.h
+++ b/source/tools/Random.h
@@ -203,6 +203,16 @@ namespace emp {
     }
 
     /**
+     * Generate a random 64-bit block of bits.
+     *
+     * @return The pseudo random number.
+     **/
+    inline uint64_t GetUInt64() {
+      return ( static_cast<uint64_t>(GetUInt()) << 32)
+             + static_cast<uint64_t>(GetUInt());
+    }
+
+    /**
      * Generate an uint64_t.
      *
      * @return The pseudo random number.
@@ -371,10 +381,10 @@ namespace emp {
 
     /**
      * By default GetRandBinomial calls the full (non-approximation) version.
-     * 
+     *
      * Note that if approximations are okay, they can create a big speedup
      * for n > 1000.
-     * 
+     *
      * @see Random::GetFullRandBinomial
      * @see Random::GetApproxRandBinomial
      * @see emp::Binomial in source/tools/Binomial.h

--- a/tests/test_tools.cc
+++ b/tests/test_tools.cc
@@ -1045,7 +1045,7 @@ TEST_CASE("Test NullStream", "[tools]")
 
 TEST_CASE("Test random", "[tools]")
 {
-  emp::Random rng;
+  emp::Random rng(1);
 
   // Test GetDouble with the law of large numbers.
   emp::vector<int> val_counts(10);

--- a/tests/test_tools.cc
+++ b/tests/test_tools.cc
@@ -1121,7 +1121,7 @@ TEST_CASE("Test random", "[tools]")
   total = 0.0;
   for (size_t i = 0; i < num_tests; i++) {
     const uint64_t cur_value = rng.GetUInt64();
-    total += cur_value;
+    total += cur_value/(double)num_tests;
     uint64_draws.push_back(cur_value);
   }
 
@@ -1129,7 +1129,7 @@ TEST_CASE("Test random", "[tools]")
   const double expected_mean = ((double)std::numeric_limits<uint64_t>::max())/2.0;
   const double min_threshold = (expected_mean*0.995);
   const double max_threshold = (expected_mean*1.005);
-  double mean_value = total/(double) num_tests;
+  double mean_value = total; // values were divided by num_tests when added
 
   REQUIRE(mean_value > min_threshold);
   REQUIRE(mean_value < max_threshold);

--- a/tests/test_tools.cc
+++ b/tests/test_tools.cc
@@ -1045,7 +1045,7 @@ TEST_CASE("Test NullStream", "[tools]")
 
 TEST_CASE("Test random", "[tools]")
 {
-  emp::Random rng(1);
+  emp::Random rng;
 
   // Test GetDouble with the law of large numbers.
   emp::vector<int> val_counts(10);

--- a/tests/test_tools.cc
+++ b/tests/test_tools.cc
@@ -15,6 +15,8 @@
 #include <string>
 #include <deque>
 #include <algorithm>
+#include <limits>
+#include <numeric>
 
 #include "data/DataNode.h"
 
@@ -1087,6 +1089,57 @@ TEST_CASE("Test random", "[tools]")
 
     REQUIRE(mean_value > min_threshold);
     REQUIRE(mean_value < max_threshold);
+  }
+
+  // Test GetUInt()
+  emp::vector<uint32_t> uint32_draws;
+  total = 0.0;
+  for (size_t i = 0; i < num_tests; i++) {
+    const uint32_t cur_value = rng.GetUInt();
+    total += cur_value;
+    uint32_draws.push_back(cur_value);
+  }
+
+  {
+  const double expected_mean = ((double)std::numeric_limits<uint32_t>::max())/2.0;
+  const double min_threshold = (expected_mean*0.995);
+  const double max_threshold = (expected_mean*1.005);
+  double mean_value = total/(double) num_tests;
+
+  REQUIRE(mean_value > min_threshold);
+  REQUIRE(mean_value < max_threshold);
+  // ensure that all bits are set at least once and unset at least once
+  REQUIRE(std::numeric_limits<uint32_t>::max() == std::accumulate(uint32_draws.begin(),uint32_draws.end(),(uint32_t)0,
+    [](uint32_t accumulator, uint32_t val){ return accumulator | val; })
+  );
+  REQUIRE(std::numeric_limits<uint32_t>::max() == std::accumulate(uint32_draws.begin(),uint32_draws.end(),(uint32_t)0,
+    [](uint32_t accumulator, uint32_t val){ return accumulator | (~val); })
+  );
+  }
+  // Test GetUInt64
+  emp::vector<uint64_t> uint64_draws;
+  total = 0.0;
+  for (size_t i = 0; i < num_tests; i++) {
+    const uint64_t cur_value = rng.GetUInt64();
+    total += cur_value;
+    uint64_draws.push_back(cur_value);
+  }
+
+  {
+  const double expected_mean = ((double)std::numeric_limits<uint64_t>::max())/2.0;
+  const double min_threshold = (expected_mean*0.995);
+  const double max_threshold = (expected_mean*1.005);
+  double mean_value = total/(double) num_tests;
+
+  REQUIRE(mean_value > min_threshold);
+  REQUIRE(mean_value < max_threshold);
+  // ensure that all bits are set at least once and unset at least once
+  REQUIRE(std::numeric_limits<uint64_t>::max() == std::accumulate(uint64_draws.begin(),uint64_draws.end(),(uint64_t)0,
+    [](uint64_t accumulator, uint64_t val){ return accumulator | val; })
+  );
+  REQUIRE(std::numeric_limits<uint64_t>::max() == std::accumulate(uint64_draws.begin(),uint64_draws.end(),(uint64_t)0,
+    [](uint64_t accumulator, uint64_t val){ return accumulator | (~val); })
+  );
   }
 
   // Test P


### PR DESCRIPTION
The function `GetUInt64()` draws uniformly over all possible `uint64_t`'s, analogously to the function `GetUInt()`.

I also added some tests for `GetUInt()`.