### PR TITLE
ActivationHandle

### DIFF
--- a/source/tools/ActivationHandle.h
+++ b/source/tools/ActivationHandle.h
@@ -33,8 +33,8 @@ namespace emp {
       ActivationHandle(
         bool active_,
         Args&&... args
-      ) : active(active_),
-        obj(std::make_optional<T>(std::forward<Args>(args)...))
+      ) : active(active_)
+        , obj(std::make_optional<T>(std::forward<Args>(args)...))
       { ; }
       /// construct the handle and its object,
       /// forwarding arguments to make the object in place
@@ -42,8 +42,7 @@ namespace emp {
       template<typename... Args>
       ActivationHandle(
         Args&&... args
-      ) : active(true),
-        obj(std::make_optional<T>(std::forward<Args>(args)...))
+      ) : ActivationHandle(true, std::forward<Args>(args)...)
       { ; }
 
       /// override the dereference operator, returning the obj or nullopt

--- a/source/tools/ActivationHandle.h
+++ b/source/tools/ActivationHandle.h
@@ -12,7 +12,7 @@
 #ifndef EMP_ACTIVATION_HANDLE_H
 #define EMP_ACTIVATION_HANDLE_H
 
-#include <optional>
+#include "base/Ptr.h"
 
 namespace emp {
 
@@ -22,7 +22,7 @@ namespace emp {
 
     private:
       bool active;
-      std::optional<T> obj;
+      T obj;
 
     public:
 
@@ -34,7 +34,7 @@ namespace emp {
         bool active_,
         Args&&... args
       ) : active(active_)
-        , obj(std::make_optional<T>(std::forward<Args>(args)...))
+        , obj(std::forward<Args>(args)...)
       { ; }
       /// construct the handle and its object,
       /// forwarding arguments to make the object in place
@@ -47,7 +47,7 @@ namespace emp {
 
       /// override the dereference operator, returning the obj or nullopt
       /// depending on activation state
-      std::optional<T> operator *() { return active ? obj : std::nullopt; }
+      emp::Ptr<T> operator *() { return active ? &obj : nullptr; }
 
       /// toggle the activation state
       void Toggle() { active = !active; }

--- a/source/tools/ActivationHandle.h
+++ b/source/tools/ActivationHandle.h
@@ -1,0 +1,63 @@
+/**
+ *  @note This file is part of Empirical, https://github.com/devosoft/Empirical
+ *  @copyright Copyright (C) Michigan State University, MIT Software license; see doc/LICENSE.md
+ *  @date 2019
+ *
+ *  @file  ActivationHandle.h
+ *  @brief A generic handle that, depending on its current activation state, will dereference as an empty std::optional or a full std::optional.
+ *  @note Status: BETA
+ */
+
+
+#ifndef EMP_ACTIVATION_HANDLE_H
+#define EMP_ACTIVATION_HANDLE_H
+
+#include <optional>
+
+namespace emp {
+
+
+  template<typename T>
+  class ActivationHandle {
+
+    private:
+      bool active;
+      std::optional<T> obj;
+
+    public:
+
+      /// construct the handle and its object,
+      /// forwarding arguments to make the object in place
+      /// inside a std::optional
+      template<typename... Args>
+      ActivationHandle(
+        bool active_,
+        Args&&... args
+      ) : active(active_),
+        obj(std::make_optional<T>(std::forward<Args>(args)...))
+      { ; }
+      /// construct the handle and its object,
+      /// forwarding arguments to make the object in place
+      /// inside a std::optional
+      template<typename... Args>
+      ActivationHandle(
+        Args&&... args
+      ) : active(true),
+        obj(std::make_optional<T>(std::forward<Args>(args)...))
+      { ; }
+
+      /// override the dereference operator, returning the obj or nullopt
+      /// depending on activation state
+      std::optional<T> operator *() { return active ? obj : std::nullopt; }
+
+      /// toggle the activation state
+      void Toggle() { active = !active; }
+
+      /// set the activation state
+      void Set(bool s) { active = s; }
+
+  };
+
+}
+
+#endif

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -2,7 +2,7 @@ GCOV_FLAGS = -o0 -g --coverage
 
 TEST_NAMES = assert base constexpr data evo geometry meta scholar systematics tools games hardware
 
-FLAGS = -std=c++17 -Wall -Wno-unused-function -I../source/ -I../
+FLAGS = -std=c++14 -Wall -Wno-unused-function -I../source/ -I../
 #CXX = clang++-6.0
 #CXX = g++
 
@@ -32,16 +32,16 @@ test: test-prep $(addprefix test-, $(TEST_NAMES))
 	rm -rf test*.out
 
 # Test optimized version without debug features
-opt: FLAGS := -std=c++17 -DNDEBUG -O3 -Wno-unused-function -I../source/ -I../
+opt: FLAGS := -std=c++14 -DNDEBUG -O3 -Wno-unused-function -I../source/ -I../
 opt: test-prep $(addprefix test-, $(TEST_NAMES))
 	rm -rf test*.out
 
 # Test in debug mode with pointer tracking
-fulldebug: FLAGS := -std=c++17 -g -Wall -Wno-unused-function -I../source/ -I../ -pedantic -DEMP_TRACK_MEM -Wnon-virtual-dtor -Wcast-align -Woverloaded-virtual -ftemplate-backtrace-limit=0 # -Wmisleading-indentation
+fulldebug: FLAGS := -std=c++14 -g -Wall -Wno-unused-function -I../source/ -I../ -pedantic -DEMP_TRACK_MEM -Wnon-virtual-dtor -Wcast-align -Woverloaded-virtual -ftemplate-backtrace-limit=0 # -Wmisleading-indentation
 fulldebug: test-prep $(addprefix test-, $(TEST_NAMES))
 	rm -rf test*.out
 
-cranky: FLAGS := -std=c++17 -g -Wall -Wno-unused-function -I../source/ -I../ -pedantic -DEMP_TRACK_MEM -Wnon-virtual-dtor -Wcast-align -Woverloaded-virtual -Wconversion -Weffc++
+cranky: FLAGS := -std=c++14 -g -Wall -Wno-unused-function -I../source/ -I../ -pedantic -DEMP_TRACK_MEM -Wnon-virtual-dtor -Wcast-align -Woverloaded-virtual -Wconversion -Weffc++
 cranky: test-prep $(addprefix test-, $(TEST_NAMES))
 	rm -rf test*.out
 
@@ -52,7 +52,7 @@ test-web:
 coverage_conversion:
 	  ./convert_for_tests.sh
 
-test-coverage: FLAGS := -std=c++17 -g -Wall -Wno-unused-function -I../coverage_source/ -I../ -DEMP_TRACK_MEM -Wnon-virtual-dtor -Wcast-align -Woverloaded-virtual -ftemplate-backtrace-limit=0 -fprofile-instr-generate -fcoverage-mapping -fno-inline -fno-elide-constructors -O0
+test-coverage: FLAGS := -std=c++14 -g -Wall -Wno-unused-function -I../coverage_source/ -I../ -DEMP_TRACK_MEM -Wnon-virtual-dtor -Wcast-align -Woverloaded-virtual -ftemplate-backtrace-limit=0 -fprofile-instr-generate -fcoverage-mapping -fno-inline -fno-elide-constructors -O0
 test-coverage: coverage_conversion test-prep $(addprefix cover-test-, $(TEST_NAMES))
 	       rm -r ../coverage_source
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -2,7 +2,7 @@ GCOV_FLAGS = -o0 -g --coverage
 
 TEST_NAMES = assert base constexpr data evo geometry meta scholar systematics tools games hardware
 
-FLAGS = -std=c++14 -Wall -Wno-unused-function -I../source/ -I../
+FLAGS = -std=c++17 -Wall -Wno-unused-function -I../source/ -I../
 #CXX = clang++-6.0
 #CXX = g++
 
@@ -32,16 +32,16 @@ test: test-prep $(addprefix test-, $(TEST_NAMES))
 	rm -rf test*.out
 
 # Test optimized version without debug features
-opt: FLAGS := -std=c++14 -DNDEBUG -O3 -Wno-unused-function -I../source/ -I../ 
+opt: FLAGS := -std=c++17 -DNDEBUG -O3 -Wno-unused-function -I../source/ -I../
 opt: test-prep $(addprefix test-, $(TEST_NAMES))
 	rm -rf test*.out
 
 # Test in debug mode with pointer tracking
-fulldebug: FLAGS := -std=c++14 -g -Wall -Wno-unused-function -I../source/ -I../ -pedantic -DEMP_TRACK_MEM -Wnon-virtual-dtor -Wcast-align -Woverloaded-virtual -ftemplate-backtrace-limit=0 # -Wmisleading-indentation
+fulldebug: FLAGS := -std=c++17 -g -Wall -Wno-unused-function -I../source/ -I../ -pedantic -DEMP_TRACK_MEM -Wnon-virtual-dtor -Wcast-align -Woverloaded-virtual -ftemplate-backtrace-limit=0 # -Wmisleading-indentation
 fulldebug: test-prep $(addprefix test-, $(TEST_NAMES))
 	rm -rf test*.out
 
-cranky: FLAGS := -std=c++14 -g -Wall -Wno-unused-function -I../source/ -I../ -pedantic -DEMP_TRACK_MEM -Wnon-virtual-dtor -Wcast-align -Woverloaded-virtual -Wconversion -Weffc++
+cranky: FLAGS := -std=c++17 -g -Wall -Wno-unused-function -I../source/ -I../ -pedantic -DEMP_TRACK_MEM -Wnon-virtual-dtor -Wcast-align -Woverloaded-virtual -Wconversion -Weffc++
 cranky: test-prep $(addprefix test-, $(TEST_NAMES))
 	rm -rf test*.out
 
@@ -52,7 +52,7 @@ test-web:
 coverage_conversion:
 	  ./convert_for_tests.sh
 
-test-coverage: FLAGS := -std=c++14 -g -Wall -Wno-unused-function -I../coverage_source/ -I../ -DEMP_TRACK_MEM -Wnon-virtual-dtor -Wcast-align -Woverloaded-virtual -ftemplate-backtrace-limit=0 -fprofile-instr-generate -fcoverage-mapping -fno-inline -fno-elide-constructors -O0 
+test-coverage: FLAGS := -std=c++17 -g -Wall -Wno-unused-function -I../coverage_source/ -I../ -DEMP_TRACK_MEM -Wnon-virtual-dtor -Wcast-align -Woverloaded-virtual -ftemplate-backtrace-limit=0 -fprofile-instr-generate -fcoverage-mapping -fno-inline -fno-elide-constructors -O0
 test-coverage: coverage_conversion test-prep $(addprefix cover-test-, $(TEST_NAMES))
 	       rm -r ../coverage_source
 

--- a/tests/test_tools.cc
+++ b/tests/test_tools.cc
@@ -18,6 +18,7 @@
 
 #include "data/DataNode.h"
 
+#include "tools/ActivationHandle.h"
 #include "tools/Binomial.h"
 #include "tools/BitMatrix.h"
 #include "tools/BitSet.h"
@@ -68,6 +69,77 @@
     static_assert(A == B, #A " == " #B); \
     REQUIRE(A == B);                     \
   }
+
+
+TEST_CASE("Test ActivationHandle", "[tools]")
+{
+
+  auto a = emp::ActivationHandle<int>(false,1);
+  REQUIRE(!*a);
+  a.Toggle();
+  REQUIRE(*a);
+  REQUIRE(**a == 1);
+  a.Set(false);
+  REQUIRE(!*a);
+  a.Set(false);
+  REQUIRE(!*a);
+  a.Toggle();
+  REQUIRE(*a);
+  REQUIRE(**a == 1);
+  a.Set(true);
+  REQUIRE(*a);
+  REQUIRE(**a == 1);
+  a.Set(false);
+  REQUIRE(!*a);
+  a.Set(true);
+  REQUIRE(*a);
+  REQUIRE(**a == 1);
+
+
+  auto b = emp::ActivationHandle<int>(true,2);
+  REQUIRE(*b);
+  REQUIRE(**b == 2);
+  b.Toggle();
+  REQUIRE(!*b);
+  b.Set(true);
+  REQUIRE(*b);
+  REQUIRE(**b == 2);
+  b.Set(true);
+  REQUIRE(*b);
+  REQUIRE(**b == 2);
+  b.Toggle();
+  REQUIRE(!*b);
+  b.Set(false);
+  REQUIRE(!*b);
+  b.Set(true);
+  REQUIRE(*b);
+  REQUIRE(**b == 2);
+  b.Set(false);
+  REQUIRE(!*b);
+
+  auto c = emp::ActivationHandle<int>(3);
+  REQUIRE(*c);
+  REQUIRE(**c == 3);
+  c.Toggle();
+  REQUIRE(!*c);
+  c.Set(true);
+  REQUIRE(*c);
+  REQUIRE(**c == 3);
+  c.Set(true);
+  REQUIRE(*c);
+  REQUIRE(**c == 3);
+  c.Toggle();
+  REQUIRE(!*c);
+  c.Set(false);
+  REQUIRE(!*c);
+  c.Set(true);
+  REQUIRE(*c);
+  REQUIRE(**c == 3);
+  c.Set(false);
+  REQUIRE(!*c);
+
+
+}
 
 
 TEST_CASE("Test Binomial", "[tools]")


### PR DESCRIPTION
A handle which can be controlled to be made to look like it's empty... potentially useful when you have an object you want to temporarily deactivate but not delete (e.g., like maybe for a tile containing a dead cell). 

Dereferencing the ActivationHandle<T> yields a std::optional<T>, which --- depending on whether the state of ActivationHandle is "on" or "off" --- is either empty or contains the object the handle is wrapping.

```
 auto a = emp::ActivationHandle<int>(false,1);
  REQUIRE(!*a);
  a.Toggle();
  REQUIRE(*a);
  REQUIRE(**a == 1);
  a.Set(false);
  REQUIRE(!*a);
  a.Set(true);
  REQUIRE(*a);
  REQUIRE(**a == 1);
```