### PR TITLE
Add ClearProgram function to SignalGP hardware

### DIFF
--- a/source/hardware/EventDrivenGP.h
+++ b/source/hardware/EventDrivenGP.h
@@ -722,6 +722,13 @@ namespace emp {
       program.Clear();
     }
 
+    /// clear program, this also requires resetting hardware
+    void ResetProgram() {
+      emp_assert(!is_executing);
+      ResetHardware();
+      program.Clear();
+    }
+
     /// Reset only hardware, not program.
     /// Not allowed to reset hardware during execution.
     void ResetHardware() {

--- a/tests/test_hardware.cc
+++ b/tests/test_hardware.cc
@@ -12,9 +12,9 @@
 
 TEST_CASE("Test SignalGP ('EventDrivenGP.h')", "[hardware]")
 {
-  // A few useful aliases: 
+  // A few useful aliases:
   using hardware_t = emp::EventDrivenGP_AW<16>;  // SignalGP hardware with 16-bit tags.
-  using inst_lib_t = emp::InstLib<hardware_t>;   // Instruction library 
+  using inst_lib_t = emp::InstLib<hardware_t>;   // Instruction library
   using event_lib_t = emp::EventLib<hardware_t>; // Event library
   using inst_t = hardware_t::Instruction;
   using event_t = hardware_t::Event;
@@ -25,7 +25,7 @@ TEST_CASE("Test SignalGP ('EventDrivenGP.h')", "[hardware]")
   constexpr double HW_MIN_SIM_THRESH = 0.0;
   constexpr size_t HW_MAX_THREADS = 32;
   constexpr size_t HW_MAX_CALL_DEPTH = 128;
-  
+
   emp::Random random(RANDOM_SEED);
   inst_lib_t inst_lib;
   event_lib_t event_lib;
@@ -34,21 +34,21 @@ TEST_CASE("Test SignalGP ('EventDrivenGP.h')", "[hardware]")
   hardware_t hw1(&inst_lib, &event_lib, &random);
   hardware_t hw2(&inst_lib, &event_lib, &random);
 
-  // Configure the hardware. 
+  // Configure the hardware.
   hw1.SetMinBindThresh(HW_MIN_SIM_THRESH);
   hw1.SetMaxCores(HW_MAX_THREADS);
-  hw1.SetMaxCallDepth(HW_MAX_CALL_DEPTH);  
+  hw1.SetMaxCallDepth(HW_MAX_CALL_DEPTH);
   REQUIRE(hw1.GetMinBindThresh() == HW_MIN_SIM_THRESH);
   REQUIRE(hw1.GetMaxCores() == HW_MAX_THREADS);
   REQUIRE(hw1.GetMaxCallDepth() == HW_MAX_CALL_DEPTH);
 
   hw2.SetMinBindThresh(HW_MIN_SIM_THRESH);
   hw2.SetMaxCores(HW_MAX_THREADS);
-  hw2.SetMaxCallDepth(HW_MAX_CALL_DEPTH);  
+  hw2.SetMaxCallDepth(HW_MAX_CALL_DEPTH);
   REQUIRE(hw2.GetMinBindThresh() == HW_MIN_SIM_THRESH);
   REQUIRE(hw2.GetMaxCores() == HW_MAX_THREADS);
   REQUIRE(hw2.GetMaxCallDepth() == HW_MAX_CALL_DEPTH);
-  
+
   const size_t TRAIT_IDX__ID = 0;
   hw1.SetTrait(TRAIT_IDX__ID, 1);
   hw1.SetTrait(128, -0.5);
@@ -92,22 +92,22 @@ TEST_CASE("Test SignalGP ('EventDrivenGP.h')", "[hardware]")
   inst_lib.AddInst("Fork", hardware_t::Inst_Fork, 0, "Fork a new thread. Local memory contents of callee are loaded into forked thread's input memory.");
   inst_lib.AddInst("Terminate", hardware_t::Inst_Terminate, 0, "Kill current thread.");
 
-  // Add a simple MsgFriend instruction to facilitate communication between hw1 and hw2. 
+  // Add a simple MsgFriend instruction to facilitate communication between hw1 and hw2.
   inst_lib.AddInst("MsgFriend", [](hardware_t & hw, const inst_t & inst) {
     hw.TriggerEvent("Msg", inst.affinity, hw.GetCurState().output_mem);
   }, 0, "Send message to other SignalGP agent.");
 
-  // Add Msg event definition to support hw1 <--> hw2 messaging. 
+  // Add Msg event definition to support hw1 <--> hw2 messaging.
   event_lib.AddEvent("Msg", [](hardware_t & hw, const event_t & event){
-    hw.SpawnCore(event.affinity, hw.GetMinBindThresh(), event.msg); 
+    hw.SpawnCore(event.affinity, hw.GetMinBindThresh(), event.msg);
   }, "Message event");
   REQUIRE(event_lib.GetSize() == 1);
 
-  // Wait, wait! We're not done with the Msg event. So far, we've specified its name and a handler. 
+  // Wait, wait! We're not done with the Msg event. So far, we've specified its name and a handler.
   // We still need to specify what happens when a hardware triggers the event.
   event_lib.RegisterDispatchFun("Msg", [&hw1, &hw2](hardware_t & hw, const event_t & event){
     const size_t senderID = (size_t)hw.GetTrait(TRAIT_IDX__ID); // Who is sending/triggering (dispatching) this message?
-    if (senderID == 1) { hw2.QueueEvent(event); } 
+    if (senderID == 1) { hw2.QueueEvent(event); }
     else { hw1.QueueEvent(event); }
   });
 
@@ -116,13 +116,13 @@ TEST_CASE("Test SignalGP ('EventDrivenGP.h')", "[hardware]")
   hw2.Reset();
   REQUIRE(hw1.GetProgram().GetSize() == 0);
   REQUIRE(hw2.GetProgram().GetSize() == 0);
-  
-  // Add handcoded program to hw1. 
-  hw1.PushFunction();  
+
+  // Add handcoded program to hw1.
+  hw1.PushFunction();
   hw1.GetProgram()[0].affinity.SetAll();
   hw1.PushInst("SetMem", 0, 16, 0, tag_t());
   hw1.PushInst("Commit", 0, 0);
-  
+
   hw1.PushFunction();                        // Tag will be all zeros
   hw1.PushInst("Input", 0, 0);
   hw1.PushInst("While", 0);
@@ -157,7 +157,7 @@ TEST_CASE("Test SignalGP ('EventDrivenGP.h')", "[hardware]")
   const size_t min_fun_len = 1;
   const size_t max_fun_len = 32;
 
-  // Evaluate a bunch of randomly generated programs. 
+  // Evaluate a bunch of randomly generated programs.
   for (size_t i = 0; i < 1000; ++i) {
     // Generate program for hardware 1
     hardware_t::Program prog1(&inst_lib);
@@ -174,7 +174,7 @@ TEST_CASE("Test SignalGP ('EventDrivenGP.h')", "[hardware]")
                               hardware_t::affinity_t());
         new_fun.inst_seq.back().affinity.Randomize(random);
       }
-      prog1.PushFunction(new_fun); 
+      prog1.PushFunction(new_fun);
     }
 
     // Generate program for hardware 2
@@ -185,7 +185,7 @@ TEST_CASE("Test SignalGP ('EventDrivenGP.h')", "[hardware]")
       new_fun.affinity.Randomize(random);
 
       size_t icnt = random.GetUInt(min_fun_len, max_fun_len);
-      
+
       for (size_t iID = 0; iID < icnt; ++iID) {
         new_fun.PushInst(random.GetUInt(prog2.GetInstLib()->GetSize()),
                               random.GetInt(max_arg_val),
@@ -194,7 +194,7 @@ TEST_CASE("Test SignalGP ('EventDrivenGP.h')", "[hardware]")
                               hardware_t::affinity_t());
         new_fun.inst_seq.back().affinity.Randomize(random);
       }
-      prog2.PushFunction(new_fun); 
+      prog2.PushFunction(new_fun);
     }
     // Hard reset
     hw1.Reset();
@@ -216,10 +216,10 @@ TEST_CASE("Test SignalGP ('EventDrivenGP.h') utility: GenRandSignalGPTag", "[har
   constexpr size_t RANDOM_SEED = 1;
   emp::Random random(RANDOM_SEED);
 
-  std::unordered_set<uint32_t> uset; // Will be used to double-check uniqueness. 
+  std::unordered_set<uint32_t> uset; // Will be used to double-check uniqueness.
 
-  // Generate a bunch of big random tags. No uniqueness guarantees. 
-  for (size_t i = 0; i < 100; ++i) auto tag = emp::GenRandSignalGPTag<1024>(random); 
+  // Generate a bunch of big random tags. No uniqueness guarantees.
+  for (size_t i = 0; i < 100; ++i) auto tag = emp::GenRandSignalGPTag<1024>(random);
 
   // Enumerate all 2-bit tags
   emp::vector<emp::BitSet<2>> tags2;
@@ -227,15 +227,15 @@ TEST_CASE("Test SignalGP ('EventDrivenGP.h') utility: GenRandSignalGPTag", "[har
   std::cout << "All two-bit tags: " << std::endl;
   for (size_t i = 0; i < emp::Pow2(2); ++i) {
     tags2.emplace_back(emp::GenRandSignalGPTag<2>(random, tags2));
-    uset.emplace(tags2.back().GetUInt(0)); 
-    std::cout << "  "; 
-    tags2.back().Print(); 
+    uset.emplace(tags2.back().GetUInt(0));
+    std::cout << "  ";
+    tags2.back().Print();
     std::cout << " : " << tags2.back().GetUInt(0) << std::endl;
   }
   REQUIRE(tags2.size() == emp::Pow2(2));
   REQUIRE(uset.size() == emp::Pow2(2));
   for (size_t i = 0; i < emp::Pow2(2); ++i) REQUIRE(emp::Has(uset, i));
-  
+
   // Enumerate all 4-bit tags
   emp::vector<emp::BitSet<4>> tags4;
   uset.clear();
@@ -243,15 +243,15 @@ TEST_CASE("Test SignalGP ('EventDrivenGP.h') utility: GenRandSignalGPTag", "[har
   for (size_t i = 0; i < emp::Pow2(4); ++i) {
     tags4.emplace_back(emp::GenRandSignalGPTag<4>(random, tags4));
     uset.emplace(tags4.back().GetUInt(0));
-    std::cout << "  "; 
-    tags4.back().Print(); 
+    std::cout << "  ";
+    tags4.back().Print();
     std::cout << " : " << tags4.back().GetUInt(0) << std::endl;
   }
   REQUIRE(tags4.size() == emp::Pow2(4));
   REQUIRE(uset.size() == emp::Pow2(4));
   for (size_t i = 0; i < emp::Pow2(4); ++i) REQUIRE(emp::Has(uset, i));
 
-  // Generate a bunch of 16-bit tags. 
+  // Generate a bunch of 16-bit tags.
   emp::vector<emp::BitSet<16>> tags16;
   for (size_t k = 0; k < 100; ++k) {
     uset.clear();
@@ -261,14 +261,14 @@ TEST_CASE("Test SignalGP ('EventDrivenGP.h') utility: GenRandSignalGPTag", "[har
       uset.emplace(tags16.back().GetUInt(0));
     }
     REQUIRE(uset.size() == 1000);
-  }  
+  }
 }
 
 TEST_CASE("Test SignalGP ('EventDrivenGP.h') utility: GenRandSignalGPTags", "[hardware]") {
   constexpr size_t RANDOM_SEED = 1;
   emp::Random random(RANDOM_SEED);
 
-  std::unordered_set<uint32_t> uset; // Will be used to double-check uniqueness. 
+  std::unordered_set<uint32_t> uset; // Will be used to double-check uniqueness.
 
   // Generate lots of small tags with no guarantees on uniqueness.
   auto small_tags = emp::GenRandSignalGPTags<2>(random, 1000);
@@ -297,16 +297,16 @@ TEST_CASE("Test SignalGP ('EventDrivenGP.h') utility: GenRandSignalGPTags", "[ha
   REQUIRE(uset.size() == emp::Pow2(4));
   for (size_t i = 0; i < emp::Pow2(4); ++i) REQUIRE(emp::Has(uset, i));
 
-  // Generate a bunch of 8-bit tags (50% of the tag-space). 
-  // Check for uniqueness. 
+  // Generate a bunch of 8-bit tags (50% of the tag-space).
+  // Check for uniqueness.
   auto tags8 = emp::GenRandSignalGPTags<8>(random, 128, true);
   uset.clear();
   for (size_t i = 0; i < tags8.size(); ++i) uset.emplace(tags8[i].GetUInt(0));
   REQUIRE(tags8.size() == 128);
   REQUIRE(uset.size() == 128);
 
-  // Generate a bunch of 8-bit tags using previously generated tag as 
-  // reserved tag-space. Check for proper uniqueness. 
+  // Generate a bunch of 8-bit tags using previously generated tag as
+  // reserved tag-space. Check for proper uniqueness.
   for (size_t i = 0; i < 100; ++i) {
     std::unordered_set<uint32_t> temp_set(uset);
     auto tags = emp::GenRandSignalGPTags<8>(random, 64, true, tags8);
@@ -319,7 +319,7 @@ TEST_CASE("Test SignalGP ('EventDrivenGP.h') utility: GenRandSignalGPTags", "[ha
 
 TEST_CASE("Test SignalGP ('EventDrivenGP.h') utility: GenRandSignalGPInst", "[hardware]") {
   using hardware_t = emp::EventDrivenGP_AW<16>;  // SignalGP hardware with 16-bit tags.
-  using inst_lib_t = emp::InstLib<hardware_t>;   // Instruction library 
+  using inst_lib_t = emp::InstLib<hardware_t>;   // Instruction library
   using inst_t = hardware_t::Instruction;
 
   constexpr int RANDOM_SEED = 1;
@@ -327,7 +327,7 @@ TEST_CASE("Test SignalGP ('EventDrivenGP.h') utility: GenRandSignalGPInst", "[ha
   constexpr size_t MAX_ARG_VAL = 15;
   emp::Random random(RANDOM_SEED);
 
-  // Build a limited instruction library. 
+  // Build a limited instruction library.
   inst_lib_t inst_lib;
   inst_lib.AddInst("Inc", hardware_t::Inst_Inc, 1, "Increment value in local memory Arg1");
   inst_lib.AddInst("Dec", hardware_t::Inst_Dec, 1, "Decrement value in local memory Arg1");
@@ -342,7 +342,7 @@ TEST_CASE("Test SignalGP ('EventDrivenGP.h') utility: GenRandSignalGPInst", "[ha
   inst_lib.AddInst("SetMem", hardware_t::Inst_SetMem, 2, "Local memory: Arg1 = numerical value of Arg2");
   inst_lib.AddInst("Fork", hardware_t::Inst_Fork, 0, "Fork a new thread. Local memory contents of callee are loaded into forked thread's input memory.");
 
-  // Generate a bunch of random instructions, check that they conform with requested bounds. 
+  // Generate a bunch of random instructions, check that they conform with requested bounds.
   for (size_t i = 0; i < 10000; ++i) {
     inst_t inst(emp::GenRandSignalGPInst(random, inst_lib, MIN_ARG_VAL, MAX_ARG_VAL));
     REQUIRE(inst.args[0] >= MIN_ARG_VAL);
@@ -357,12 +357,12 @@ TEST_CASE("Test SignalGP ('EventDrivenGP.h') utility: GenRandSignalGPInst", "[ha
 
 TEST_CASE("Test SignalGP ('EventDrivenGP.h') utility: GenRandSignalGPFunction", "[hardware]") {
   using hardware_t = emp::EventDrivenGP_AW<16>;  // SignalGP hardware with 16-bit tags.
-  using inst_lib_t = emp::InstLib<hardware_t>;   // Instruction library 
+  using inst_lib_t = emp::InstLib<hardware_t>;   // Instruction library
   using inst_t = typename hardware_t::Instruction;
   using fun_t = typename hardware_t::Function;
 
   constexpr int RANDOM_SEED = 1;
-  
+
   constexpr size_t MIN_ARG_VAL = 0;
   constexpr size_t MAX_ARG_VAL = 15;
   constexpr size_t MIN_INST_CNT = 1;
@@ -370,7 +370,7 @@ TEST_CASE("Test SignalGP ('EventDrivenGP.h') utility: GenRandSignalGPFunction", 
 
   emp::Random random(RANDOM_SEED);
 
-  // Build a limited instruction library. 
+  // Build a limited instruction library.
   inst_lib_t inst_lib;
   inst_lib.AddInst("Inc", hardware_t::Inst_Inc, 1, "Increment value in local memory Arg1");
   inst_lib.AddInst("Dec", hardware_t::Inst_Dec, 1, "Decrement value in local memory Arg1");
@@ -385,8 +385,8 @@ TEST_CASE("Test SignalGP ('EventDrivenGP.h') utility: GenRandSignalGPFunction", 
   inst_lib.AddInst("SetMem", hardware_t::Inst_SetMem, 2, "Local memory: Arg1 = numerical value of Arg2");
   inst_lib.AddInst("Fork", hardware_t::Inst_Fork, 0, "Fork a new thread. Local memory contents of callee are loaded into forked thread's input memory.");
 
-  // Generate a bunch of random functions. 
-  // Check that constraints weren't violated. 
+  // Generate a bunch of random functions.
+  // Check that constraints weren't violated.
   for (size_t f = 0; f < 10000; ++f) {
     fun_t fun(emp::GenRandSignalGPFunction(random, inst_lib, MIN_INST_CNT, MAX_INST_CNT, MIN_ARG_VAL, MAX_ARG_VAL));
     REQUIRE(fun.GetSize() >= MIN_INST_CNT);
@@ -406,14 +406,14 @@ TEST_CASE("Test SignalGP ('EventDrivenGP.h') utility: GenRandSignalGPFunction", 
 
 TEST_CASE("Test SignalGP ('EventDrivenGP.h') utility: GenRandSignalGPProgram", "[hardware]") {
   using hardware_t = emp::EventDrivenGP_AW<16>;  // SignalGP hardware with 16-bit tags.
-  using inst_lib_t = emp::InstLib<hardware_t>;   // Instruction library 
+  using inst_lib_t = emp::InstLib<hardware_t>;   // Instruction library
   using event_lib_t = emp::EventLib<hardware_t>;
   using inst_t = typename hardware_t::Instruction;
   using fun_t = typename hardware_t::Function;
   using program_t = typename hardware_t::Program;
 
   constexpr int RANDOM_SEED = 1;
-  
+
   constexpr size_t MIN_ARG_VAL = 0;
   constexpr size_t MAX_ARG_VAL = 15;
   constexpr size_t MIN_INST_CNT = 1;
@@ -427,7 +427,7 @@ TEST_CASE("Test SignalGP ('EventDrivenGP.h') utility: GenRandSignalGPProgram", "
 
   emp::Random random(RANDOM_SEED);
 
-  // Build a limited instruction library. 
+  // Build a limited instruction library.
   inst_lib_t inst_lib;
   inst_lib.AddInst("Inc", hardware_t::Inst_Inc, 1, "Increment value in local memory Arg1");
   inst_lib.AddInst("Dec", hardware_t::Inst_Dec, 1, "Decrement value in local memory Arg1");
@@ -442,14 +442,14 @@ TEST_CASE("Test SignalGP ('EventDrivenGP.h') utility: GenRandSignalGPProgram", "
   inst_lib.AddInst("SetMem", hardware_t::Inst_SetMem, 2, "Local memory: Arg1 = numerical value of Arg2");
   inst_lib.AddInst("Fork", hardware_t::Inst_Fork, 0, "Fork a new thread. Local memory contents of callee are loaded into forked thread's input memory.");
 
-  // We'll use some SignalGP hardware to test randomly generated programs. 
+  // We'll use some SignalGP hardware to test randomly generated programs.
   event_lib_t event_lib;
   hardware_t hw(&inst_lib, &event_lib, &random);
   hw.SetMinBindThresh(HW_MIN_SIM_THRESH);
   hw.SetMaxCores(HW_MAX_THREADS);
-  hw.SetMaxCallDepth(HW_MAX_CALL_DEPTH);  
+  hw.SetMaxCallDepth(HW_MAX_CALL_DEPTH);
 
-  // Generate a bunch of random programs. 
+  // Generate a bunch of random programs.
   // Check that constraints weren't violated.
   for (size_t p = 0; p < 1000; ++p) {
     program_t program(emp::GenRandSignalGPProgram(random, inst_lib, MIN_FUN_CNT, MAX_FUN_CNT, MIN_INST_CNT, MAX_INST_CNT, MIN_ARG_VAL, MAX_ARG_VAL));
@@ -480,11 +480,11 @@ TEST_CASE("Test SignalGP ('EventDrivenGP.h') utility: GenRandSignalGPProgram", "
 
 TEST_CASE("Test SignalGP ('EventDrivenGP.h') utility: SignalGPMutator struct", "[hardware]") {
   using hardware_t = emp::EventDrivenGP_AW<16>;  // SignalGP hardware with 16-bit tags.
-  using inst_lib_t = emp::InstLib<hardware_t>;   // Instruction library 
+  using inst_lib_t = emp::InstLib<hardware_t>;   // Instruction library
   using program_t = typename hardware_t::Program;
 
   constexpr int RANDOM_SEED = 1;
-  
+
   size_t MIN_ARG_VAL = 0;
   size_t MAX_ARG_VAL = 15;
   size_t MIN_FUNC_LEN = 1;
@@ -494,13 +494,13 @@ TEST_CASE("Test SignalGP ('EventDrivenGP.h') utility: SignalGPMutator struct", "
   size_t MAX_TOTAL_LEN = 1024;
 
   emp::Random random(RANDOM_SEED);
-  
-  auto mutator = emp::SignalGPMutator<16>(MIN_FUNC_CNT, MAX_FUNC_CNT, 
-                                          MIN_FUNC_LEN, MAX_FUNC_LEN, 
-                                          MAX_TOTAL_LEN, 
+
+  auto mutator = emp::SignalGPMutator<16>(MIN_FUNC_CNT, MAX_FUNC_CNT,
+                                          MIN_FUNC_LEN, MAX_FUNC_LEN,
+                                          MAX_TOTAL_LEN,
                                           MIN_ARG_VAL, MAX_ARG_VAL);
 
-  // Build a limited instruction library. 
+  // Build a limited instruction library.
   inst_lib_t inst_lib;
   inst_lib.AddInst("Inc", hardware_t::Inst_Inc, 1, "Increment value in local memory Arg1");
   inst_lib.AddInst("Dec", hardware_t::Inst_Dec, 1, "Decrement value in local memory Arg1");
@@ -516,7 +516,7 @@ TEST_CASE("Test SignalGP ('EventDrivenGP.h') utility: SignalGPMutator struct", "
   inst_lib.AddInst("Fork", hardware_t::Inst_Fork, 0, "Fork a new thread. Local memory contents of callee are loaded into forked thread's input memory.");
   inst_lib.AddInst("Nop", hardware_t::Inst_Nop, 0, "No operation.");
 
-  // Check parameter adding. 
+  // Check parameter adding.
   size_t default_param_cnt = mutator.GetParamCnt();
   size_t param1_id = mutator.AddParam("test1", 1.0, "Test parameter one!");
   size_t param2_id = mutator.AddParam("test2", 2.0, "Test parameter two!");
@@ -527,25 +527,25 @@ TEST_CASE("Test SignalGP ('EventDrivenGP.h') utility: SignalGPMutator struct", "
   REQUIRE(mutator.GetParamName(param1_id) == "test1");
   REQUIRE(mutator.GetParamDesc(param1_id) == "Test parameter one!");
   REQUIRE(mutator.GetParamID("test1") == param1_id);
-  // Check parameter editing. 
+  // Check parameter editing.
   mutator.SetParam(param1_id, 10.0);
   REQUIRE(mutator.GetParam(param1_id) == 10.0);
   mutator.SetParam(param1_id, 100.0);
   REQUIRE(mutator.GetParam("test1") == 100.0);
 
-  // Add mutators. 
+  // Add mutators.
   size_t default_mutator_cnt = mutator.GetMutatorCnt();
   mutator.ClearMutators();
   REQUIRE(mutator.GetMutatorCnt() == 0);
   mutator.AddMutator("99BottlesOfNothing", [](program_t &, emp::Random &) { return 99; }, "This mutator does nothing and returns 99.");
-  mutator.AddMutator("AllFunTagsAllOnes", [](program_t & p, emp::Random & r) { 
+  mutator.AddMutator("AllFunTagsAllOnes", [](program_t & p, emp::Random & r) {
     for (size_t fID = 0; fID < p.GetSize(); ++fID) {
       p[fID].GetAffinity().SetAll();
     }
     return p.GetSize();
   });
 
-  // Generate a nop program to test custom mutators on. 
+  // Generate a nop program to test custom mutators on.
   program_t nop_prog(&inst_lib);
   for (size_t f = 0; f < 3; ++f) {
     nop_prog.PushFunction();
@@ -555,8 +555,8 @@ TEST_CASE("Test SignalGP ('EventDrivenGP.h') utility: SignalGPMutator struct", "
   REQUIRE(mutator.GetLastMutationCnt("99BottlesOfNothing") == 99);
   REQUIRE(mutator.GetLastMutationCnt("AllFunTagsAllOnes") == 3);
   REQUIRE(total_muts == 102);
-  
-  // Check removing a mutator. 
+
+  // Check removing a mutator.
   mutator.RemoveMutator("99BottlesOfNothing");
   REQUIRE(mutator.GetMutatorCnt() == 1);
   mutator.RemoveMutator("AllFunTagsAllOnes");
@@ -574,9 +574,9 @@ TEST_CASE("Test SignalGP ('EventDrivenGP.h') utility: SignalGPMutator struct", "
   mutator.ARG_SUB__PER_ARG(0.5);
   mutator.INST_SUB__PER_INST(0.5);
   mutator.TAG_BIT_FLIP__PER_BIT(0.5);
-  // Generate many random programs, apply mutations, check constraints. 
+  // Generate many random programs, apply mutations, check constraints.
   for (size_t i = 0; i < 1000; ++i) {
-    program_t prog(emp::GenRandSignalGPProgram(random, inst_lib, 
+    program_t prog(emp::GenRandSignalGPProgram(random, inst_lib,
                                               1, 8,
                                               mutator.GetProgMinFuncLen(), mutator.GetProgMaxFuncLen(),
                                               mutator.GetProgMinArgVal(), mutator.GetProgMaxArgVal()));
@@ -586,7 +586,7 @@ TEST_CASE("Test SignalGP ('EventDrivenGP.h') utility: SignalGPMutator struct", "
     }
   }
 
-  // Zero out all of the mutation rates. 
+  // Zero out all of the mutation rates.
   mutator.ARG_SUB__PER_ARG(0.0);
   mutator.INST_SUB__PER_INST(0.0);
   mutator.INST_INS__PER_INST(0.0);
@@ -595,7 +595,7 @@ TEST_CASE("Test SignalGP ('EventDrivenGP.h') utility: SignalGPMutator struct", "
   mutator.FUNC_DUP__PER_FUNC(0.0);
   mutator.FUNC_DEL__PER_FUNC(0.0);
   mutator.TAG_BIT_FLIP__PER_BIT(0.0);
-  program_t prog1(emp::GenRandSignalGPProgram(random, inst_lib, 
+  program_t prog1(emp::GenRandSignalGPProgram(random, inst_lib,
                                               mutator.GetProgMinFuncCnt(), mutator.GetProgMaxFuncCnt(),
                                               mutator.GetProgMinFuncLen(), mutator.GetProgMaxFuncLen(),
                                               mutator.GetProgMinArgVal(), mutator.GetProgMaxArgVal()));

--- a/tests/test_hardware.cc
+++ b/tests/test_hardware.cc
@@ -111,6 +111,16 @@ TEST_CASE("Test SignalGP ('EventDrivenGP.h')", "[hardware]")
     else { hw1.QueueEvent(event); }
   });
 
+  hw1.ResetProgram();
+  hw2.ResetProgram();
+
+  REQUIRE(hw1.GetProgram().GetSize() == 0);
+  REQUIRE(hw2.GetProgram().GetSize() == 0);
+
+  REQUIRE(hw1.GetTrait(TRAIT_IDX__ID) == 1);
+  REQUIRE(hw1.GetTrait(128) == -0.5);
+  REQUIRE(hw2.GetTrait(TRAIT_IDX__ID) == 2);
+
   // Do a hard reset
   hw1.Reset();
   hw2.Reset();
@@ -196,6 +206,12 @@ TEST_CASE("Test SignalGP ('EventDrivenGP.h')", "[hardware]")
       }
       prog2.PushFunction(new_fun);
     }
+
+    hw1.SetTrait(TRAIT_IDX__ID, 1);
+    hw1.ResetProgram();
+    REQUIRE(hw1.GetProgram().GetSize() == 0);
+    REQUIRE(hw1.GetTrait(TRAIT_IDX__ID) == 1);
+
     // Hard reset
     hw1.Reset();
     hw2.Reset();


### PR DESCRIPTION
I assume this also requires resetting hardware or bad things might happen? This functionality is useful if you want to have persistent traits, but need to be able to reset everything else.