### PR TITLE
Fix path to Empirical directory

### DIFF
--- a/examples/ProjectTemplate/Makefile
+++ b/examples/ProjectTemplate/Makefile
@@ -1,6 +1,6 @@
 # Project-specific settings
 PROJECT := project_name
-EMP_DIR := ../../Empirical/source
+EMP_DIR := ../../../Empirical/source
 
 # Flags to use regardless of compiler
 CFLAGS_all := -Wall -Wno-unused-function -std=c++14 -I$(EMP_DIR)/


### PR DESCRIPTION
The `Makefile` in question is `examples/ProjectTemplate/Makefile`.

The `EMP_DIR` path is currently listed as `../../Empirical`. If we want users to be able to compile the Hello World example in its current location, the `EMP_DIR` path should be `../../../Empirical`. This is the change my PR makes. If we want the user to be able to compile the Hello World Example when the user copies the `examples/ProjectTemplate` outside of the `Empirical` directory (e.g., next to it), then `EMP_DIR` path should be `../Empirical`. Either way, the current `EMP_DIR` needs to be fixed.