### PR TITLE
Add Inst_RngDouble to EventDrivenGP.h

### DIFF
--- a/source/hardware/EventDrivenGP.h
+++ b/source/hardware/EventDrivenGP.h
@@ -1659,6 +1659,14 @@ namespace emp {
       hw.TriggerEvent("Message", inst.affinity, state.output_mem, {"send"});
     }
 
+    /// Non-default instruction: RngDouble
+    /// Number of arguments: 1
+    /// Description: Draw a value between 0 and 1 from the onboard RNG and store it in Local[Arg1]
+    static void Inst_RngDouble(EventDrivenGP_t & hw, const inst_t & inst) {
+      State & state = hw.GetCurState();
+      state.SetLocal(inst.args[0], hw.GetRandom().GetDouble());
+    }
+    
     /// Get a pointer to const default instruction library. Will only construct the default instruction library once.
     static Ptr<const InstLib<EventDrivenGP_t>> DefaultInstLib() {
       static inst_lib_t inst_lib;

--- a/tests/test_hardware.cc
+++ b/tests/test_hardware.cc
@@ -91,7 +91,8 @@ TEST_CASE("Test SignalGP ('EventDrivenGP.h')", "[hardware]")
   inst_lib.AddInst("Nop", hardware_t::Inst_Nop, 0, "No operation.");
   inst_lib.AddInst("Fork", hardware_t::Inst_Fork, 0, "Fork a new thread. Local memory contents of callee are loaded into forked thread's input memory.");
   inst_lib.AddInst("Terminate", hardware_t::Inst_Terminate, 0, "Kill current thread.");
-
+  inst_lib.AddInst("RngDouble", hardware_t::Inst_RngDouble, 1, "Draw a double between 0 and 1 from onboard RNG.");
+  
   // Add a simple MsgFriend instruction to facilitate communication between hw1 and hw2.
   inst_lib.AddInst("MsgFriend", [](hardware_t & hw, const inst_t & inst) {
     hw.TriggerEvent("Msg", inst.affinity, hw.GetCurState().output_mem);


### PR DESCRIPTION
This instruction draws a value between 0 and 1 from the hardware's onboard RNG and stores it in Local[Arg1]. It's potentially useful to many users, so worthwhile to have available in the header files. Due to political considerations, though, don't add it to the default instruction set so that, by default, SignalGP programs are deterministic.