### PR TITLE
Bye bye Pointer_stringify

### DIFF
--- a/apps/utils/graphs/web/web_UI.h
+++ b/apps/utils/graphs/web/web_UI.h
@@ -19,7 +19,7 @@ public:
        << "<tr><th>Line</th><th>Instruction</th><th>Arg 1</th><th>Arg 2</th><th>Arg 3</th></tr>";
 
     EM_ASM_ARGS({
-        var code = Pointer_stringify($0);
+        var code = UTF8ToString($0);
         var code_obj = document.getElementById("code");
         code_obj.innerHTML = code;
     }, ss.str().c_str());

--- a/source/base/assert.h
+++ b/source/base/assert.h
@@ -144,7 +144,7 @@ namespace emp {
     ss << "Assert Error (In " << filename << " line " << line << "): " << expr << '\n';
     assert_print(ss, std::forward<EXTRA>(extra)...);
     if (emp::TripAssert() <= 3) {
-      EM_ASM_ARGS({ msg = Pointer_stringify($0); alert(msg); }, ss.str().c_str());
+      EM_ASM_ARGS({ msg = UTF8ToString($0); alert(msg); }, ss.str().c_str());
     }
 
     // Print the current state of the stack.

--- a/source/base/errors.h
+++ b/source/base/errors.h
@@ -130,7 +130,7 @@ namespace emp {
     std::stringstream ss;
     Notify_impl(ss, std::forward<Ts>(args)...);
 #ifdef EMSCRIPTEN
-    EM_ASM_ARGS({ msg = Pointer_stringify($0); alert(msg); }, ss.str().c_str());
+    EM_ASM_ARGS({ msg = UTF8ToString($0); alert(msg); }, ss.str().c_str());
 #else
     std::cerr << ss.str() << std::endl;
 #endif

--- a/source/tools/alert.h
+++ b/source/tools/alert.h
@@ -21,7 +21,7 @@
 
 namespace emp {
 #ifdef EMSCRIPTEN
-  void Alert(const std::string & msg) { EM_ASM_ARGS({ msg = Pointer_stringify($0); alert(msg); }, msg.c_str()); }
+  void Alert(const std::string & msg) { EM_ASM_ARGS({ msg = UTF8ToString($0); alert(msg); }, msg.c_str()); }
 #else
   /// Send msg to cerr if in C++, or show msg in an alert box if compiled to Javascript
   /// Input can be any number of arguments of any types as long as the can be converted to

--- a/source/web/Attributes.h
+++ b/source/web/Attributes.h
@@ -86,7 +86,7 @@ namespace web {
       // Find the current object only once.
 #ifdef EMSCRIPTEN
       EM_ASM_ARGS({
-          var id = Pointer_stringify($0);
+          var id = UTF8ToString($0);
           emp_i.cur_obj = $( '#' + id );
         }, widget_id.c_str());
 #endif
@@ -95,8 +95,8 @@ namespace web {
         if (attr_pair.second == "") continue; // Ignore empty entries.
 #ifdef EMSCRIPTEN
         EM_ASM_ARGS({
-            var name = Pointer_stringify($0);
-            var value = Pointer_stringify($1);
+            var name = UTF8ToString($0);
+            var value = UTF8ToString($1);
             emp_i.cur_obj.attr( name, value);
           }, attr_pair.first.c_str(), attr_pair.second.c_str());
 #else
@@ -112,9 +112,9 @@ namespace web {
 
 #ifdef EMSCRIPTEN
       EM_ASM_ARGS({
-          var id = Pointer_stringify($0);
-          var setting = Pointer_stringify($1);
-          var value = Pointer_stringify($2);
+          var id = UTF8ToString($0);
+          var setting = UTF8ToString($1);
+          var value = UTF8ToString($2);
           $( '#' + id ).attr( setting, value);
         }, widget_id.c_str(), setting.c_str(), settings[setting].c_str());
 #else
@@ -128,9 +128,9 @@ namespace web {
                       const std::string & value) {
 #ifdef EMSCRIPTEN
       EM_ASM_ARGS({
-          var id = Pointer_stringify($0);
-          var setting = Pointer_stringify($1);
-          var value = Pointer_stringify($2);
+          var id = UTF8ToString($0);
+          var setting = UTF8ToString($1);
+          var value = UTF8ToString($2);
           $( '#' + id ).attr( setting, value);
         }, widget_id.c_str(), setting.c_str(), value.c_str());
 #else

--- a/source/web/Canvas.h
+++ b/source/web/Canvas.h
@@ -56,7 +56,7 @@ namespace web {
       // Setup a canvas to be drawn on.
       void TargetCanvas() {
         EM_ASM_ARGS({
-            var cname = Pointer_stringify($0);
+            var cname = UTF8ToString($0);
             var canvas = document.getElementById(cname);
             emp_i.ctx = canvas.getContext('2d');
         }, id.c_str());

--- a/source/web/CanvasAction.h
+++ b/source/web/CanvasAction.h
@@ -147,7 +147,7 @@ namespace web {
         }
       });
     }
-    
+
     CanvasAction * Clone() const { return new CanvasImage(*this); }
   };
 

--- a/source/web/CanvasAction.h
+++ b/source/web/CanvasAction.h
@@ -37,7 +37,7 @@ namespace web {
     void Fill(const std::string & style="") {
       if (style != "") {
         EM_ASM_ARGS({
-            emp_i.ctx.fillStyle = Pointer_stringify($0);
+            emp_i.ctx.fillStyle = UTF8ToString($0);
           }, style.c_str());
       }
       EM_ASM({ emp_i.ctx.fill(); });
@@ -47,7 +47,7 @@ namespace web {
     void Stroke(const std::string & style="") {
       if (style != "") {
         EM_ASM_ARGS({
-            emp_i.ctx.strokeStyle = Pointer_stringify($0);
+            emp_i.ctx.strokeStyle = UTF8ToString($0);
           }, style.c_str());
       }
       EM_ASM({ emp_i.ctx.stroke(); });
@@ -80,7 +80,7 @@ namespace web {
 
     void Apply() {
       EM_ASM_ARGS({
-        var color = Pointer_stringify($0);
+        var color = UTF8ToString($0);
         emp_i.ctx.strokeStyle = color;
       }, color.c_str());
     }
@@ -112,7 +112,7 @@ namespace web {
 
     void Apply() {
       EM_ASM_ARGS({
-        emp_i.ctx.font = Pointer_stringify($0);
+        emp_i.ctx.font = UTF8ToString($0);
       }, font.c_str());
     }
     CanvasAction * Clone() const { return new CanvasFont(*this); }

--- a/source/web/CanvasShape.h
+++ b/source/web/CanvasShape.h
@@ -239,8 +239,8 @@ namespace web {
         EM_ASM({ emp_i.ctx.textBaseline = "middle"; });
       }
       EM_ASM_ARGS({
-        emp_i.ctx.fillStyle = Pointer_stringify($3);
-        var text = Pointer_stringify($2);
+        emp_i.ctx.fillStyle = UTF8ToString($3);
+        var text = UTF8ToString($2);
         emp_i.ctx.fillText(text,$0,$1);
       }, p.GetX(), p.GetY(), text.c_str(), fill_color.c_str());
     }

--- a/source/web/Div.h
+++ b/source/web/Div.h
@@ -142,8 +142,8 @@ namespace web {
         if (state == Widget::ACTIVE) {
           // Create a span tag to anchor the new widget.
           EM_ASM_ARGS({
-              parent_id = Pointer_stringify($0);
-              child_id = Pointer_stringify($1);
+              parent_id = UTF8ToString($0);
+              child_id = UTF8ToString($1);
               $('#' + parent_id).append('<span id="' + child_id + '"></span>');
             }, id.c_str(), in.GetID().c_str());
 
@@ -226,7 +226,7 @@ namespace web {
 
         if (scroll_top >= 0.0) {
           EM_ASM_ARGS({
-              var div_id = Pointer_stringify($0);
+              var div_id = UTF8ToString($0);
               var div_obj = document.getElementById(div_id);
               if (div_obj == null) alert(div_id);
               // alert('id=' + div_id + '  top=' + $1 +
@@ -241,7 +241,7 @@ namespace web {
     // if (scroll_frac < 0.0) scroll_frac = 0.0;
 
     // EM_ASM_ARGS({
-    //     var code = Pointer_stringify($0);
+    //     var code = UTF8ToString($0);
     //     var code_obj = document.getElementById("code");
     //     code_obj.innerHTML = code;
     //     code_obj.scrollTop = $1 * code_obj.scrollHeight;

--- a/source/web/JSWrap.h
+++ b/source/web/JSWrap.h
@@ -73,7 +73,7 @@ namespace emp {
   struct LoadTuple;
 
   /// This needs to go before LoadTuple is defined, in case there are nested tuple structs
-  template <int ARG_ID, typename T> static 
+  template <int ARG_ID, typename T> static
   void LoadArg(T & arg_var) {
     if constexpr ( is_introspective_tuple<T>() ) {
       using JSON_TYPE = T;

--- a/source/web/JSWrap.h
+++ b/source/web/JSWrap.h
@@ -110,70 +110,70 @@ namespace emp {
   //Helper functions to load arguments from inside Javascript objects by name.
   template <int ARG_ID> static void LoadArg(int16_t & arg_var, std::string var) {
     arg_var = (int16_t) EM_ASM_INT({
-      return emp_i.curr_obj[Pointer_stringify($0)];
+      return emp_i.curr_obj[UTF8ToString($0)];
     }, var.c_str());
   }
 
   template <int ARG_ID> static void LoadArg(int32_t & arg_var, std::string var) {
     arg_var = (int32_t) EM_ASM_INT({
-      return emp_i.curr_obj[Pointer_stringify($0)];
+      return emp_i.curr_obj[UTF8ToString($0)];
     }, var.c_str());
   }
 
   template <int ARG_ID> static void LoadArg(int64_t & arg_var, std::string var) {
     arg_var = (int64_t) EM_ASM_DOUBLE({
-      return emp_i.curr_obj[Pointer_stringify($0)];
+      return emp_i.curr_obj[UTF8ToString($0)];
     }, var.c_str());
   }
 
   template <int ARG_ID> static void LoadArg(uint16_t & arg_var, std::string var) {
     arg_var = (uint16_t) EM_ASM_INT({
-      return emp_i.curr_obj[Pointer_stringify($0)];
+      return emp_i.curr_obj[UTF8ToString($0)];
     }, var.c_str());
   }
 
   template <int ARG_ID> static void LoadArg(uint32_t & arg_var, std::string var) {
     arg_var = (uint32_t) EM_ASM_INT({
-      return emp_i.curr_obj[Pointer_stringify($0)];
+      return emp_i.curr_obj[UTF8ToString($0)];
     }, var.c_str());
   }
 
   template <int ARG_ID> static void LoadArg(uint64_t & arg_var, std::string var) {
     arg_var = (uint64_t) EM_ASM_DOUBLE({
-      return emp_i.curr_obj[Pointer_stringify($0)];
+      return emp_i.curr_obj[UTF8ToString($0)];
     }, var.c_str());
   }
 
   template <int ARG_ID> static void LoadArg(bool & arg_var, std::string var) {
     arg_var = (bool) EM_ASM_INT({
-      return emp_i.curr_obj[Pointer_stringify($0)];
+      return emp_i.curr_obj[UTF8ToString($0)];
     }, var.c_str());
   }
 
   template <int ARG_ID> static void LoadArg(char & arg_var, std::string var) {
     arg_var = (char) EM_ASM_INT({
-      return emp_i.curr_obj[Pointer_stringify($0)];
+      return emp_i.curr_obj[UTF8ToString($0)];
     }, var.c_str());
   }
 
   template <int ARG_ID> static void LoadArg(double & arg_var, std::string var) {
     arg_var = EM_ASM_DOUBLE({
-      return emp_i.curr_obj[Pointer_stringify($0)];
+      return emp_i.curr_obj[UTF8ToString($0)];
     }, var.c_str());
   }
 
   template <int ARG_ID> static void LoadArg(float & arg_var, std::string var) {
     arg_var = (float) EM_ASM_DOUBLE({
-      return emp_i.curr_obj[Pointer_stringify($0)];
+      return emp_i.curr_obj[UTF8ToString($0)];
     }, var.c_str());
   }
 
   template <int ARG_ID> static void LoadArg(std::string & arg_var, std::string var) {
     char * tmp_var = (char *) EM_ASM_INT({
-      if (emp_i.curr_obj[Pointer_stringify($0)] == null){
-        emp_i.curr_obj[Pointer_stringify($0)] = "undefined";
+      if (emp_i.curr_obj[UTF8ToString($0)] == null){
+        emp_i.curr_obj[UTF8ToString($0)] = "undefined";
       }
-      return allocate(intArrayFromString(emp_i.curr_obj[Pointer_stringify($0)]),
+      return allocate(intArrayFromString(emp_i.curr_obj[UTF8ToString($0)]),
                       'i8', ALLOC_STACK);
     }, var.c_str());
     arg_var = tmp_var;   // Free memory here?
@@ -186,7 +186,7 @@ namespace emp {
     //LoadArg<ARG_ID>(std::get<ARG_ID>(arg_var.emp__tuple_body));
     EM_ASM_ARGS({
       emp_i.object_queue.push(emp_i.curr_obj);
-      emp_i.curr_obj = emp_i.curr_obj[Pointer_stringify($0)];
+      emp_i.curr_obj = emp_i.curr_obj[UTF8ToString($0)];
     }, var.c_str());
     LoadTuple<JSON_TYPE, ARG_ID, JSON_TYPE::n_fields> load_tuple = LoadTuple<JSON_TYPE, ARG_ID, JSON_TYPE::n_fields>();
     load_tuple.LoadJSDataArg(arg_var);
@@ -226,7 +226,7 @@ namespace emp {
   }
 
   static void StoreReturn(const std::string & ret_var) {
-    EM_ASM_ARGS({ emp_i.cb_return = Pointer_stringify($0); }, ret_var.c_str());
+    EM_ASM_ARGS({ emp_i.cb_return = UTF8ToString($0); }, ret_var.c_str());
   }
 
   template <typename T, size_t N>
@@ -244,22 +244,22 @@ namespace emp {
 
   /// Helper functions to store values inside JSON objects
   static void StoreReturn(const int & ret_var, std::string var) {
-    EM_ASM_ARGS({ emp_i.curr_obj[Pointer_stringify($1)] = $0; }, ret_var, var.c_str());
+    EM_ASM_ARGS({ emp_i.curr_obj[UTF8ToString($1)] = $0; }, ret_var, var.c_str());
   }
 
   static void StoreReturn(const double & ret_var, std::string var) {
-    EM_ASM_ARGS({ emp_i.curr_obj[Pointer_stringify($1)] = $0; }, ret_var, var.c_str());
+    EM_ASM_ARGS({ emp_i.curr_obj[UTF8ToString($1)] = $0; }, ret_var, var.c_str());
   }
 
   static void StoreReturn(const std::string & ret_var, std::string var) {
-    EM_ASM_ARGS({ emp_i.curr_obj[Pointer_stringify($1)] = Pointer_stringify($0); }
+    EM_ASM_ARGS({ emp_i.curr_obj[UTF8ToString($1)] = UTF8ToString($0); }
                                                     , ret_var.c_str(), var.c_str());
   }
 
   template <typename T, size_t N>
   static void StoreReturn(const emp::array<T, N> & ret_var, std::string var) {
     pass_array_to_javascript(ret_var);
-    EM_ASM_ARGS({ emp_i.curr_obj[Pointer_stringify($0)] = emp_i.__incoming_array;}, var.c_str());
+    EM_ASM_ARGS({ emp_i.curr_obj[UTF8ToString($0)] = emp_i.__incoming_array;}, var.c_str());
   }
 
   template <typename JSON_TYPE, int FIELD>
@@ -284,9 +284,9 @@ namespace emp {
   static emp::sfinae_decoy<void, decltype(RETURN_TYPE::n_fields)>
   StoreReturn(const RETURN_TYPE & ret_var, std::string var) {
     EM_ASM_ARGS({
-      emp_i.curr_obj[Pointer_stringify($0)] = {};
+      emp_i.curr_obj[UTF8ToString($0)] = {};
       emp_i.object_queue.push(emp_i.curr_obj);
-      emp_i.curr_obj = emp_i.curr_obj[Pointer_stringify($0)];
+      emp_i.curr_obj = emp_i.curr_obj[UTF8ToString($0)];
     }, var.c_str());
 
     StoreTuple<RETURN_TYPE, RETURN_TYPE::n_fields> store_tuple = StoreTuple<RETURN_TYPE, RETURN_TYPE::n_fields>();
@@ -473,7 +473,7 @@ namespace emp {
 
     if (fun_name != "") {
       EM_ASM_ARGS({
-          var fun_name = Pointer_stringify($1);
+          var fun_name = UTF8ToString($1);
           emp[fun_name] = function() {
             emp_i.cb_args = [];
             for (var i = 0; i < arguments.length; i++) {

--- a/source/web/Listeners.h
+++ b/source/web/Listeners.h
@@ -84,7 +84,7 @@ namespace web {
       // Find the current object only once.
 #ifdef EMSCRIPTEN
       EM_ASM_ARGS({
-          var id = Pointer_stringify($0);
+          var id = UTF8ToString($0);
           emp_i.cur_obj = $( '#' + id );
         }, widget_id.c_str());
 #endif
@@ -92,7 +92,7 @@ namespace web {
       for (auto event_pair : listeners) {
 #ifdef EMSCRIPTEN
         EM_ASM_ARGS({
-          var name = Pointer_stringify($0);
+          var name = UTF8ToString($0);
           emp_i.cur_obj.on( name, function(evt) { emp.Callback($1, evt); } );
         }, event_pair.first.c_str(), event_pair.second);
 #else
@@ -109,8 +109,8 @@ namespace web {
                       size_t fun_id) {
 #ifdef EMSCRIPTEN
         EM_ASM_ARGS({
-          var id = Pointer_stringify($0);
-          var name = Pointer_stringify($1);
+          var id = UTF8ToString($0);
+          var name = UTF8ToString($1);
           $( '#' + id ).on( name, function(evt) { emp.Callback($2, evt); } );
         }, widget_id.c_str(), event_name.c_str(), fun_id);
 #else

--- a/source/web/RawImage.h
+++ b/source/web/RawImage.h
@@ -42,7 +42,7 @@ namespace emp {
         size_t error_callback = JSWrapOnce( std::function<void()>(std::bind(&ImageInfo::MarkError, this)) );
 
         img_id = EM_ASM_INT({
-          var url = Pointer_stringify($0);
+          var url = UTF8ToString($0);
           var img_id = emp_i.images.length;
           emp_i.images[img_id] = new Image();
           emp_i.images[img_id].src = url;

--- a/source/web/Style.h
+++ b/source/web/Style.h
@@ -88,7 +88,7 @@ namespace web {
       // Find the current object only once.
 #ifdef EMSCRIPTEN
       EM_ASM_ARGS({
-          var id = Pointer_stringify($0);
+          var id = UTF8ToString($0);
           emp_i.cur_obj = $( '#' + id );
         }, widget_id.c_str());
 #endif
@@ -97,8 +97,8 @@ namespace web {
         if (css_pair.second == "") continue; // Ignore empty entries.
 #ifdef EMSCRIPTEN
         EM_ASM_ARGS({
-            var name = Pointer_stringify($0);
-            var value = Pointer_stringify($1);
+            var name = UTF8ToString($0);
+            var value = UTF8ToString($1);
             emp_i.cur_obj.css( name, value);
           }, css_pair.first.c_str(), css_pair.second.c_str());
 #else
@@ -114,9 +114,9 @@ namespace web {
 
 #ifdef EMSCRIPTEN
       EM_ASM_ARGS({
-          var id = Pointer_stringify($0);
-          var setting = Pointer_stringify($1);
-          var value = Pointer_stringify($2);
+          var id = UTF8ToString($0);
+          var setting = UTF8ToString($1);
+          var value = UTF8ToString($2);
           $( '#' + id ).css( setting, value);
         }, widget_id.c_str(), setting.c_str(), settings[setting].c_str());
 #else
@@ -130,9 +130,9 @@ namespace web {
                       const std::string & value) {
 #ifdef EMSCRIPTEN
       EM_ASM_ARGS({
-          var id = Pointer_stringify($0);
-          var setting = Pointer_stringify($1);
-          var value = Pointer_stringify($2);
+          var id = UTF8ToString($0);
+          var setting = UTF8ToString($1);
+          var value = UTF8ToString($2);
           $( '#' + id ).css( setting, value);
         }, widget_id.c_str(), setting.c_str(), value.c_str());
 #else

--- a/source/web/Table.h
+++ b/source/web/Table.h
@@ -210,8 +210,8 @@ namespace web {
           // Create a span tag to anchor the new widget.
           std::string cell_id = emp::to_string(id, '_', r, '_', c);
           EM_ASM_ARGS({
-              parent_id = Pointer_stringify($0);
-              child_id = Pointer_stringify($1);
+              parent_id = UTF8ToString($0);
+              child_id = UTF8ToString($1);
               $('#' + parent_id).append('<span id="' + child_id + '"></span>');
             }, cell_id.c_str(), in.GetID().c_str());
 

--- a/source/web/TextArea.h
+++ b/source/web/TextArea.h
@@ -85,8 +85,8 @@ namespace web {
 
       void UpdateText(const std::string & in_string) {
         EM_ASM_ARGS({
-            var id = Pointer_stringify($0);
-            var text = Pointer_stringify($1);
+            var id = UTF8ToString($0);
+            var text = UTF8ToString($1);
             $('#' + id).val(text);
           }, id.c_str(), in_string.c_str());
       }

--- a/source/web/Widget.h
+++ b/source/web/Widget.h
@@ -345,8 +345,8 @@ namespace web {
 
         // Now do the replacement.
         EM_ASM_ARGS({
-            var widget_id = Pointer_stringify($0);
-            var out_html = Pointer_stringify($1);
+            var widget_id = UTF8ToString($0);
+            var out_html = UTF8ToString($1);
             $('#' + widget_id).replaceWith(out_html);
           }, id.c_str(), ss.str().c_str());
 
@@ -436,7 +436,7 @@ namespace web {
     if (!info) return -1.0;
     emp_assert(GetID() != "");  // Must have a name!
     return EM_ASM_DOUBLE({
-      var id = Pointer_stringify($0);
+      var id = UTF8ToString($0);
       var rect = $('#' + id).position();
       if (rect === undefined) return -1.0;
       return rect.left;
@@ -447,7 +447,7 @@ namespace web {
     if (!info) return -1.0;
     emp_assert(GetID() != "");  // Must have a name!
     return EM_ASM_DOUBLE({
-      var id = Pointer_stringify($0);
+      var id = UTF8ToString($0);
       var rect = $('#' + id).position();
       if (rect === undefined) return -1.0;
       return rect.top;
@@ -458,7 +458,7 @@ namespace web {
     if (!info) return -1.0;
     emp_assert(GetID() != "");  // Must have a name!
     return EM_ASM_DOUBLE({
-      var id = Pointer_stringify($0);
+      var id = UTF8ToString($0);
       return $('#' + id).width();
     }, GetID().c_str());
   }
@@ -466,7 +466,7 @@ namespace web {
     if (!info) return -1.0;
     emp_assert(GetID() != "");  // Must have a name!
     return EM_ASM_DOUBLE({
-      var id = Pointer_stringify($0);
+      var id = UTF8ToString($0);
       return $('#' + id).height();
     }, GetID().c_str());
   }
@@ -474,7 +474,7 @@ namespace web {
     if (!info) return -1.0;
     emp_assert(GetID() != "");  // Must have a name!
     return EM_ASM_DOUBLE({
-      var id = Pointer_stringify($0);
+      var id = UTF8ToString($0);
       return $('#' + id).innerWidth();
     }, GetID().c_str());
   }
@@ -482,7 +482,7 @@ namespace web {
     if (!info) return -1.0;
     emp_assert(GetID() != "");  // Must have a name!
     return EM_ASM_DOUBLE({
-      var id = Pointer_stringify($0);
+      var id = UTF8ToString($0);
       return $('#' + id).innerHeight();
     }, GetID().c_str());
   }
@@ -490,7 +490,7 @@ namespace web {
     if (!info) return -1.0;
     emp_assert(GetID() != "");  // Must have a name!
     return EM_ASM_DOUBLE({
-      var id = Pointer_stringify($0);
+      var id = UTF8ToString($0);
       return $('#' + id).outerWidth();
     }, GetID().c_str());
   }
@@ -498,7 +498,7 @@ namespace web {
     if (!info) return -1.0;
     emp_assert(GetID() != "");  // Must have a name!
     return EM_ASM_DOUBLE({
-      var id = Pointer_stringify($0);
+      var id = UTF8ToString($0);
       return $('#' + id).outerHeight();
     }, GetID().c_str());
   }

--- a/source/web/Widget.h
+++ b/source/web/Widget.h
@@ -300,20 +300,20 @@ namespace web {
           const Widget widget = val;
           return Append(widget);
         }
-        
+
         // First, test if we are working with a Widget command.
         if constexpr ( std::is_base_of<WidgetCommand,T>() ) {
           const WidgetCommand & cmd = val;
           return Append(cmd);
         }
-        
+
         // Next, test if this if an invoable function
         // @CAO: We should make sure it returns a string when called with no arguments.
         else if constexpr ( std::is_invocable<T>() ) {
           std::function<std::string()> fun_val( val );
           return Append(fun_val);
         }
-        
+
         // Anything else we should just try to convert to a string, and used that.
         else {
           return Append(emp::to_string(val));

--- a/source/web/d3/axis.h
+++ b/source/web/d3/axis.h
@@ -88,13 +88,13 @@ namespace D3 {
         var axis_range = js.objects[$0].scale().range();
 	    js.objects[$3] = js.objects[$1].append("g");
 
-        js.objects[$3].append("g").attr("id", Pointer_stringify($2))
+        js.objects[$3].append("g").attr("id", UTF8ToString($2))
                                   .call(js.objects[$0]);
 
         var canvas_width = js.objects[$1].attr("width");
         var canvas_height = js.objects[$1].attr("height");
 
-        var orient = Pointer_stringify($6);
+        var orient = UTF8ToString($6);
         var dy = "2.5em";
         var x_divisor = 2.0;
         var text_orient = 0;
@@ -114,8 +114,8 @@ namespace D3 {
           js.objects[$3].attr("transform", "translate("+(canvas_width-60)+",0)");
         }
 
-        if (Pointer_stringify($5) != "") {
-          dy = Pointer_stringify($5);
+        if (UTF8ToString($5) != "") {
+          dy = UTF8ToString($5);
         }
 
         var label_x = axis_range[0]+(axis_range[1]-axis_range[0])/x_divisor;
@@ -124,11 +124,11 @@ namespace D3 {
         }
 
         js.objects[$3].append("text")
-             .attr("id", Pointer_stringify($2)+"_label")
+             .attr("id", UTF8ToString($2)+"_label")
              .attr("transform", "rotate("+text_orient+")")
              .attr("x", label_x)
              .attr("dy", dy).style("text-anchor", "middle")
-             .text(Pointer_stringify($4));
+             .text(UTF8ToString($4));
       }, this->id, selection.GetID(), dom_id.c_str(), group.GetID(), label.c_str(),
       label_offset.c_str(), orientation.c_str());
       return *this;
@@ -230,7 +230,7 @@ namespace D3 {
     /// [the rules for d3.format()](https://github.com/d3/d3-3.x-api-reference/blob/master/Formatting.md#d3_format)
     Axis& SetTickFormat(std::string format) {
       EM_ASM_ARGS({
-        js.objects[$0].tickFormat(d3.format(Pointer_stringify($1)));
+        js.objects[$0].tickFormat(d3.format(UTF8ToString($1)));
       }, this->id, format.c_str());
       return *this;
     }

--- a/source/web/d3/d3_init.h
+++ b/source/web/d3/d3_init.h
@@ -135,7 +135,7 @@ namespace D3 {
     /// "Data: " followed by the value of d, rounded to two decimal points.
     ToolTip(std::string func) {
       EM_ASM_ARGS({
-        var in_string = Pointer_stringify($1);
+        var in_string = UTF8ToString($1);
         if (typeof window["d3"][in_string] === "function"){
           in_string = window["d3"][in_string];
         } else if (typeof window["emp"][in_string] === "function"){
@@ -163,7 +163,7 @@ namespace D3 {
 
     void SetHtml(std::string func) {
       EM_ASM_ARGS({
-        var in_string = Pointer_stringify($1);
+        var in_string = UTF8ToString($1);
         if (typeof window["d3"][in_string] === "function"){
           in_string = window["d3"][in_string];
         } else if (typeof window["emp"][in_string] === "function"){
@@ -192,7 +192,7 @@ namespace D3 {
   public:
       FormatFunction(std::string format = "") {
         EM_ASM_ARGS({
-          js.objects[$1] = d3.format(Pointer_stringify($0));
+          js.objects[$1] = d3.format(UTF8ToString($0));
         }, format.c_str(), this->id);
       }
 
@@ -221,17 +221,17 @@ namespace D3 {
     JSFunction() {;}
     JSFunction(std::string name) {
       int fail = EM_ASM_INT({
-        var fn = window["d3"][Pointer_stringify($2)];
+        var fn = window["d3"][UTF8ToString($2)];
         if (typeof fn === "function") {
           js.objects[$0] = fn;
           return 0;
         } else {
-          var fn = window["emp"][Pointer_stringify($2)];
+          var fn = window["emp"][UTF8ToString($2)];
           if (typeof fn === "function") {
             js.objects[$0] = fn;
             return 0;
           } else {
-            var fn = window[Pointer_stringify($2)];
+            var fn = window[UTF8ToString($2)];
             if (typeof fn === "function") {
               js.objects[$0] = fn;
               return 0;

--- a/source/web/d3/dataset.h
+++ b/source/web/d3/dataset.h
@@ -98,7 +98,7 @@ namespace D3 {
 
     void LoadDataFromFile(std::string filename) {
       EM_ASM_ARGS ({
-        d3.json(Pointer_stringify($1), function(data){js.objects[$0]=data;});
+        d3.json(UTF8ToString($1), function(data){js.objects[$0]=data;});
       }, id, filename.c_str());
     }
 
@@ -107,7 +107,7 @@ namespace D3 {
       emp::JSWrap(fun, "__json_load_fun__"+emp::to_string(id));
 
       EM_ASM_ARGS ({
-        d3.json(Pointer_stringify($1), function(data){
+        d3.json(UTF8ToString($1), function(data){
             js.objects[$0]=data;
             emp["__json_load_fun__"+$0](data);
         });
@@ -118,7 +118,7 @@ namespace D3 {
       emp::JSWrap(fun, "__json_load_fun__"+emp::to_string(id));
       std::cout << filename.c_str() << std::endl;
       EM_ASM_ARGS ({
-        var filename = Pointer_stringify($1);
+        var filename = UTF8ToString($1);
         d3.json(filename, function(data){
             js.objects[$0]=data;
             console.log(filename, data);
@@ -130,7 +130,7 @@ namespace D3 {
 
     void Append(std::string json) {
       EM_ASM_ARGS({
-        js.objects[$0].push(JSON.parse(Pointer_stringify($1)));
+        js.objects[$0].push(JSON.parse(UTF8ToString($1)));
       }, this->id, json.c_str());
     }
 
@@ -138,7 +138,7 @@ namespace D3 {
 
       int fail = EM_ASM_INT({
 
-        var obj = JSON.parse(Pointer_stringify($2));
+        var obj = JSON.parse(UTF8ToString($2));
 
         var result = null;
         for (var i in js.objects[$0]) {
@@ -165,7 +165,7 @@ namespace D3 {
       int pos = EM_ASM_INT({
         var parent_node = null;
         var pos = -1;
-        var child_node = JSON.parse(Pointer_stringify($1));
+        var child_node = JSON.parse(UTF8ToString($1));
         for (var item in js.objects[$0]) {
           if (js.objects[$0][item].name == child_node.parent) {
             parent_node = js.objects[$0][item];
@@ -198,8 +198,8 @@ namespace D3 {
             return ([+d[0], +d[1]]);
         };
 
-        var arg1 = Pointer_stringify($0);
-        var in_string = Pointer_stringify($1);
+        var arg1 = UTF8ToString($0);
+        var in_string = UTF8ToString($1);
         if (typeof window[in_string] === "function"){
           in_string = window[in_string];
         } else if (typeof window["d3"][in_string] === "function") {

--- a/source/web/d3/histogram.h
+++ b/source/web/d3/histogram.h
@@ -54,7 +54,7 @@ namespace D3 {
 
         Histogram& SetThresholds(std::string threshold_generator) {
             EM_ASM_ARGS({
-                js.objects[$0].thresholds(Pointer_stringify($1));
+                js.objects[$0].thresholds(UTF8ToString($1));
             }, this->id, threshold_generator.c_str());
             return (*this);
         }

--- a/source/web/d3/scales.h
+++ b/source/web/d3/scales.h
@@ -133,7 +133,7 @@ namespace D3 {
     IdentityScale& SetTickFormat(int count, std::string format) {
       //TODO: format is technically optional, but what is the point of this
       //function without it?
-      EM_ASM_ARGS({js.objects[$0].tick($1, Pointer_stringify($2));},
+      EM_ASM_ARGS({js.objects[$0].tick($1, UTF8ToString($2));},
 		  this->id, count, format.c_str());
       return *this;
     }

--- a/source/web/d3/selection.h
+++ b/source/web/d3/selection.h
@@ -48,7 +48,7 @@ namespace D3 {
         int new_id = NextD3ID();
 
         EM_ASM_ARGS({
-  	      var new_selection = js.objects[$0].select(Pointer_stringify($1));
+  	      var new_selection = js.objects[$0].select(UTF8ToString($1));
   	      js.objects[$2] = new_selection;
         }, this->id, selector.c_str(), new_id);
 
@@ -62,7 +62,7 @@ namespace D3 {
 
         EM_ASM_ARGS({
         //   console.log($0, js.objects[$0]);
-  	      var new_selection = js.objects[$0].selectAll(Pointer_stringify($1));
+  	      var new_selection = js.objects[$0].selectAll(UTF8ToString($1));
           js.objects[$2] = new_selection;
         }, this->id, selector.c_str(), new_id);
 
@@ -79,7 +79,7 @@ namespace D3 {
       // TODO: Allow arguments
       DERIVED& Call(std::string function){
         EM_ASM_ARGS({
-          var func_string = Pointer_stringify($1);
+          var func_string = UTF8ToString($1);
           if (typeof window[func_string] === "function") {
             func_string = window[func_string];
           } else if (typeof window["emp"][func_string] === "function") {
@@ -219,7 +219,7 @@ namespace D3 {
       typename std::enable_if<std::is_fundamental<T>::value, DERIVED&>::type
       SetAttr(std::string name, T value) {
 
-        EM_ASM_ARGS({js.objects[$0].attr(Pointer_stringify($1), $2)},
+        EM_ASM_ARGS({js.objects[$0].attr(UTF8ToString($1), $2)},
     		  this->id, name.c_str(), value);
         return *(static_cast<DERIVED *>(this));
       }
@@ -235,7 +235,7 @@ namespace D3 {
         uint32_t fun_id = emp::JSWrap(value, "", false);
 
         EM_ASM_ARGS({
-          js.objects[$0].attr(Pointer_stringify($1), function(d, i, k) {
+          js.objects[$0].attr(UTF8ToString($1), function(d, i, k) {
                                                         return emp.Callback($2, d, i, k);
                                                       });
         }, this->id, name.c_str(), fun_id);
@@ -262,7 +262,7 @@ namespace D3 {
         emp::pass_array_to_javascript(value);
 
         EM_ASM_ARGS({
-    	    js.objects[$0].attr(Pointer_stringify($1), emp_i.__incoming_array);
+    	    js.objects[$0].attr(UTF8ToString($1), emp_i.__incoming_array);
         }, this->id, name.c_str());
 
         return *(static_cast<DERIVED *>(this));
@@ -284,7 +284,7 @@ namespace D3 {
       DERIVED& SetStyle(std::string name, std::string value, bool priority=false){
         if (priority){
     	    EM_ASM_ARGS({
-            var func_string = Pointer_stringify($2);
+            var func_string = UTF8ToString($2);
     	    if (typeof window[func_string] === "function") {
               func_string = window[func_string];
             }
@@ -293,7 +293,7 @@ namespace D3 {
                 func_string = window[name][func_string];
               }
             }
-    	    js.objects[$0].style(Pointer_stringify($1), in_string, "important");
+    	    js.objects[$0].style(UTF8ToString($1), in_string, "important");
     	    }, this->id, name.c_str(), value.c_str());
         } else {
     	    D3_CALLBACK_METHOD_2_ARGS(style, name.c_str(), value.c_str())
@@ -308,7 +308,7 @@ namespace D3 {
       DERIVED& SetStyle(std::string name, const char* value, bool priority=false){
         if (priority){
     	    EM_ASM_ARGS({
-    	      var func_string = Pointer_stringify($2);
+    	      var func_string = UTF8ToString($2);
     	      if (typeof window[func_string] === "function") {
                 func_string = window[func_string];
               }
@@ -317,7 +317,7 @@ namespace D3 {
                   func_string = window[name][func_string];
                 }
               };
-    	      js.objects[$0].style(Pointer_stringify($1), in_string, "important");
+    	      js.objects[$0].style(UTF8ToString($1), in_string, "important");
     	    }, this->id, name.c_str(), value);
         } else {
     	    D3_CALLBACK_METHOD_2_ARGS(style, name.c_str(), value)
@@ -340,11 +340,11 @@ namespace D3 {
       typename std::enable_if<std::is_fundamental<T>::value, DERIVED&>::type
       SetStyle(std::string name, T value, bool priority=false){
         if (priority){
-    	    EM_ASM_ARGS({js.objects[$0].style(Pointer_stringify($1), $2, "important")},
+    	    EM_ASM_ARGS({js.objects[$0].style(UTF8ToString($1), $2, "important")},
               this->id, name.c_str(), value);
           }
         else {
-    	    EM_ASM_ARGS({js.objects[$0].style(Pointer_stringify($1), $2)},
+    	    EM_ASM_ARGS({js.objects[$0].style(UTF8ToString($1), $2)},
               this->id, name.c_str(), value);
         }
         return *(static_cast<DERIVED *>(this));
@@ -424,7 +424,7 @@ namespace D3 {
       /// Get the value of this object's [name] attribute when it's a string
       std::string GetAttrString(std::string name) const {
         char * buffer = (char *)EM_ASM_INT({
-  	      var text = js.objects[$0].attr(Pointer_stringify($1));
+  	      var text = js.objects[$0].attr(UTF8ToString($1));
   	      var buffer = Module._malloc(text.length+1);
   	      Module.writeStringToMemory(text, buffer);
   	      return buffer;
@@ -438,21 +438,21 @@ namespace D3 {
       /// Get the value of this object's [name] attribute when it's an int
       int GetAttrInt(std::string name) const {
         return EM_ASM_INT({
-  	      return js.objects[$0].attr(Pointer_stringify($1));
+  	      return js.objects[$0].attr(UTF8ToString($1));
         }, this->id, name.c_str());
       }
 
       /// Get the value of this object's [name] attribute when it's a double
       double GetAttrDouble(std::string name) const {
         return EM_ASM_DOUBLE({
-  	      return js.objects[$0].attr(Pointer_stringify($1));
+  	      return js.objects[$0].attr(UTF8ToString($1));
         }, this->id, name.c_str());
       }
 
       /// Get the value of this object's [name] style when it's a string
       std::string GetStyleString(std::string name) const {
         char * buffer = (char *)EM_ASM_INT({
-  	      var text = js.objects[$0].style(Pointer_stringify($1));
+  	      var text = js.objects[$0].style(UTF8ToString($1));
   	      var buffer = Module._malloc(text.length+1);
   	      Module.writeStringToMemory(text, buffer);
   	      return buffer;
@@ -466,14 +466,14 @@ namespace D3 {
       /// Get the value of this object's [name] style when it's an int
       int GetStyleInt(std::string name) const {
         return EM_ASM_INT({
-  	      return js.objects[$0].style(Pointer_stringify($1));
+  	      return js.objects[$0].style(UTF8ToString($1));
         }, this->id, name.c_str());
       }
 
       /// Get the value of this object's [name] style when it's a double
       double GetStyleDouble(std::string name) const {
         return EM_ASM_DOUBLE({
-  	      return js.objects[$0].style(Pointer_stringify($1));
+  	      return js.objects[$0].style(UTF8ToString($1));
         }, this->id, name.c_str());
       }
 
@@ -571,7 +571,7 @@ namespace D3 {
     Transition NewTransition(std::string name="") const {
       int new_id = NextD3ID();
       EM_ASM_ARGS({
- 	    var transition = js.objects[$0].transition(Pointer_stringify($1));
+ 	    var transition = js.objects[$0].transition(UTF8ToString($1));
 	    js.objects[$2] = transition;
     }, this->id, name.c_str(), new_id);
 
@@ -601,7 +601,7 @@ namespace D3 {
 
       // Check that the listener is valid
       emp_assert(EM_ASM_INT({
-        var func_string = Pointer_stringify($0);
+        var func_string = UTF8ToString($0);
         if (func_string == "null") {
           return true;
         }
@@ -620,7 +620,7 @@ namespace D3 {
       int new_id = NextD3ID();
 
       EM_ASM_ARGS({
-	    var func_string = Pointer_stringify($2);
+	    var func_string = UTF8ToString($2);
         if (typeof window[func_string] === "function") {
           func_string = window[func_string];
         }
@@ -631,10 +631,10 @@ namespace D3 {
         }
 
 	    if (typeof func_string === "function") {
-	      js.objects[$0].on(Pointer_stringify($1),
+	      js.objects[$0].on(UTF8ToString($1),
 		  func_string,$3);
 	    } else {
-	      js.objects[$0].on(Pointer_stringify($1), null);
+	      js.objects[$0].on(UTF8ToString($1), null);
 	    }
 
       }, this->id, type.c_str(), listener.c_str(), capture, new_id);
@@ -653,7 +653,7 @@ namespace D3 {
       int new_id = NextD3ID();
 
       EM_ASM_ARGS({
-	      js.objects[$0].on(Pointer_stringify($1),
+	      js.objects[$0].on(UTF8ToString($1),
 		  function(d, i){
 		     js.objects[$4] = d3.select(this);
 		     emp.Callback($2, d, i, $4);}, $3);
@@ -679,8 +679,8 @@ namespace D3 {
     // std::string verison
     Transition& SetProperty(std::string name, std::string value){
       EM_ASM_ARGS({
-        var arg1 = Pointer_stringify($1);				                              	\
-        var func_string = Pointer_stringify($2);
+        var arg1 = UTF8ToString($1);				                              	\
+        var func_string = UTF8ToString($2);
         if (typeof window[func_string] === "function") {
           func_string = window[func_string];
         }
@@ -701,8 +701,8 @@ namespace D3 {
     // Const char * version so raw strings work
     Transition& SetProperty(std::string name, const char* value){
       EM_ASM_ARGS({
-        var arg1 = Pointer_stringify($1);				                              	\
-        var func_string = Pointer_stringify($2);
+        var arg1 = UTF8ToString($1);				                              	\
+        var func_string = UTF8ToString($2);
         if (typeof window[func_string] === "function") {
           func_string = window[func_string];
         }
@@ -724,7 +724,7 @@ namespace D3 {
     SetProperty(std::string name, T value){
       EM_ASM_ARGS({
           js.objects[$0].each("end", function() {
-            d3.select(this).property(Pointer_stringify($1), $2);
+            d3.select(this).property(UTF8ToString($1), $2);
           });
       }, this->id, name.c_str());
       return *this;
@@ -739,7 +739,7 @@ namespace D3 {
       uint32_t fun_id = emp::JSWrap(value, "", false);
       EM_ASM_ARGS({
         js.objects[$0].each("end", function(){
-                d3.select(this).property(Pointer_stringify($1),
+                d3.select(this).property(UTF8ToString($1),
                                           function(d, i, j) {
                                             return emp.Callback($2, d, i, j);
                                         });
@@ -755,7 +755,7 @@ namespace D3 {
     /// specified function on the element's bound data
     Transition& SetHtml(std::string value){
       EM_ASM_ARGS({
-        var func_string = Pointer_stringify($1);
+        var func_string = UTF8ToString($1);
         if (typeof window[func_string] === "function") {
           func_string = window[func_string];
         }
@@ -796,7 +796,7 @@ namespace D3 {
     Transition& SetClassed(std::string classname, bool value) {
       EM_ASM_ARGS({
         js.objects[$0].each("end", function(){
-            d3.select(this).classed(Pointer_stringify($1), $2);
+            d3.select(this).classed(UTF8ToString($1), $2);
         });
       }, this->id, classname.c_str(), value);
       return *this;
@@ -811,7 +811,7 @@ namespace D3 {
       uint32_t fun_id = emp::JSWrap(func, "", false);
       EM_ASM_ARGS({
         js.objects[$0].each("end", function(){
-                  d3.select(this).classed(Pointer_stringify($1),
+                  d3.select(this).classed(UTF8ToString($1),
                                             function(d, i, j) {
                                               return emp.Callback($2, d, i, j);
                                           });
@@ -825,7 +825,7 @@ namespace D3 {
     // Version that allows strings containing function names but warns on other strings
     Transition& SetClassed(std::string classname, std::string value){
       emp_assert(EM_ASM_INT({
-        var func_string = Pointer_stringify($0);
+        var func_string = UTF8ToString($0);
         if (typeof window[func_string] === "function") {
           func_string = window[func_string];
         }
@@ -838,8 +838,8 @@ namespace D3 {
       }, value.c_str()) && "String passed to SetClassed is not a Javascript function", value);
 
       EM_ASM_ARGS({
-        var arg1 = Pointer_stringify($1);				                              	\
-        var func_string = Pointer_stringify($2);
+        var arg1 = UTF8ToString($1);				                              	\
+        var func_string = UTF8ToString($2);
         if (typeof window[func_string] === "function") {
           func_string = window[func_string];
         }
@@ -895,7 +895,7 @@ namespace D3 {
     /// Get the value of this object's [name] property when its a string
     std::string GetPropertyString(std::string name) const {
       char * buffer = (char *)EM_ASM_INT({
-        var text = d3.select(js.objects[$0]).property(Pointer_stringify($1));
+        var text = d3.select(js.objects[$0]).property(UTF8ToString($1));
         var buffer = Module._malloc(text.length+1);
         Module.writeStringToMemory(text, buffer);
         return buffer;
@@ -909,14 +909,14 @@ namespace D3 {
     /// Get the value of this object's [name] property when it's an int
     int GetPropertyInt(std::string name) const {
       return EM_ASM_INT({
-        return d3.select(js.objects[$0]).property(Pointer_stringify($1));
+        return d3.select(js.objects[$0]).property(UTF8ToString($1));
       }, this->id, name.c_str());
     }
 
     /// Get the value of this object's [name] property when it's a double
     double GetPropertyDouble(std::string name) const {
       return EM_ASM_DOUBLE({
-        return d3.select(js.objects[$0]).property(Pointer_stringify($1));
+        return d3.select(js.objects[$0]).property(UTF8ToString($1));
       }, this->id, name.c_str());
     }
 
@@ -969,12 +969,12 @@ namespace D3 {
     Selection(std::string selector, bool all = false) {
       if (all){
         EM_ASM_ARGS({
-  	      js.objects[$0] = d3.selectAll(Pointer_stringify($1));
+  	      js.objects[$0] = d3.selectAll(UTF8ToString($1));
         }, this->id, selector.c_str());
       }
       else {
         EM_ASM_ARGS({
-  	      js.objects[$0] = d3.select(Pointer_stringify($1));
+  	      js.objects[$0] = d3.select(UTF8ToString($1));
         }, this->id, selector.c_str());
       }
     };
@@ -1011,7 +1011,7 @@ namespace D3 {
       EM_ASM_ARGS({
         //We could make this slightly prettier with macros, but would
         //add an extra comparison
-	    var in_string = Pointer_stringify($1);
+	    var in_string = UTF8ToString($1);
 	    var fn = window["emp"][in_string];
 	    if (typeof fn === "function"){
 	      var update_sel = js.objects[$0].data(js.objects[$2], fn);
@@ -1085,7 +1085,7 @@ namespace D3 {
       emp::pass_array_to_javascript(values);
 
   	  EM_ASM_ARGS({
-	    var in_string = Pointer_stringify($1);
+	    var in_string = UTF8ToString($1);
 	    var fn = window["emp"][in_string];
 	    if (typeof fn === "function"){
 	      var update_sel = js.objects[$0].data(emp_i.__incoming_array, fn);
@@ -1150,7 +1150,7 @@ namespace D3 {
 
       EM_ASM_ARGS({
 	    var append_selection = js.objects[$0].enter()
-                               .append(Pointer_stringify($1));
+                               .append(UTF8ToString($1));
 	    js.objects[$2] = append_selection;
       }, this->id, type.c_str(), new_id);
 
@@ -1166,13 +1166,13 @@ namespace D3 {
 
       if (before.c_str()){
 	    EM_ASM_ARGS({
-	      var new_sel = js.objects[$0].enter().insert(Pointer_stringify($1),
-						  Pointer_stringify($2));
+	      var new_sel = js.objects[$0].enter().insert(UTF8ToString($1),
+						  UTF8ToString($2));
 	      js.objects[$3] = new_sel;
         }, this->id, name.c_str(), before.c_str(), new_id);
       } else {
 	    EM_ASM_ARGS({
-	      var new_sel = js.objects[$0].enter().insert(Pointer_stringify($1));
+	      var new_sel = js.objects[$0].enter().insert(UTF8ToString($1));
 	      js.objects[$2] = new_sel;
         }, this->id, name.c_str(), new_id);
       }
@@ -1272,7 +1272,7 @@ namespace D3 {
     template <typename T>
     typename std::enable_if<std::is_fundamental<T>::value, Selection&>::type
     SetProperty(std::string name, T value){
-      EM_ASM_ARGS({js.objects[$0].property(Pointer_stringify($1),
+      EM_ASM_ARGS({js.objects[$0].property(UTF8ToString($1),
 					   $2)}, this->id, name.c_str());
       return *this;
     }
@@ -1312,7 +1312,7 @@ namespace D3 {
     // Value can also be a function that takes bound data and returns a bool
     Selection& SetClassed(std::string classname, bool value) {
       EM_ASM_ARGS({
-        js.objects[$0].classed(Pointer_stringify($1), $2);
+        js.objects[$0].classed(UTF8ToString($1), $2);
       }, this->id, classname.c_str(), value);
       return *this;
     }
@@ -1330,7 +1330,7 @@ namespace D3 {
     // Version that allows strings containing function names but warns on other strings
     Selection& SetClassed(std::string classname, std::string value){
       emp_assert(EM_ASM_INT({
-        var func_string = Pointer_stringify($0);
+        var func_string = UTF8ToString($0);
         if (typeof window[func_string] === "function") {
           func_string = window[func_string];
         }
@@ -1384,7 +1384,7 @@ namespace D3 {
     /// Get the value of this object's [name] property when its a string
     std::string GetPropertyString(std::string name) const {
       char * buffer = (char *)EM_ASM_INT({
-	    var text = js.objects[$0].property(Pointer_stringify($1));
+	    var text = js.objects[$0].property(UTF8ToString($1));
 	    var buffer = Module._malloc(text.length+1);
 	    Module.writeStringToMemory(text, buffer);
 	    return buffer;
@@ -1398,14 +1398,14 @@ namespace D3 {
     /// Get the value of this object's [name] property when it's an int
     int GetPropertyInt(std::string name) const {
       return EM_ASM_INT({
-	    return js.objects[$0].property(Pointer_stringify($1));
+	    return js.objects[$0].property(UTF8ToString($1));
       }, this->id, name.c_str());
     }
 
     /// Get the value of this object's [name] property when it's a double
     double GetPropertyDouble(std::string name) const {
       return EM_ASM_DOUBLE({
-	    return js.objects[$0].property(Pointer_stringify($1));
+	    return js.objects[$0].property(UTF8ToString($1));
       }, this->id, name.c_str());
     }
 
@@ -1418,7 +1418,7 @@ namespace D3 {
       int new_id = NextD3ID();
 
       EM_ASM_ARGS({
-	    var new_selection = js.objects[$0].append(Pointer_stringify($1));
+	    var new_selection = js.objects[$0].append(UTF8ToString($1));
 	    js.objects[$2] = new_selection;
       }, this->id, name.c_str(), new_id);
       return Selection(new_id);
@@ -1434,13 +1434,13 @@ namespace D3 {
 
       if (before.c_str()){
 	    EM_ASM_ARGS({
-	      var new_sel = js.objects[$0].insert(Pointer_stringify($1),
-						  Pointer_stringify($2));
+	      var new_sel = js.objects[$0].insert(UTF8ToString($1),
+						  UTF8ToString($2));
 	      js.objects[$3] = new_sel;
         }, this->id, name.c_str(), before.c_str(), new_id);
       } else {
   	    EM_ASM_ARGS({
-	      var new_sel = js.objects[$0].insert(Pointer_stringify($1));
+	      var new_sel = js.objects[$0].insert(UTF8ToString($1));
 	      js.objects[$2] = new_sel;
         }, this->id, name.c_str(), new_id);
       }
@@ -1452,7 +1452,7 @@ namespace D3 {
     Transition MakeTransition(std::string name=""){
       int new_id = NextD3ID();
       EM_ASM_ARGS({
- 	    var transition = js.objects[$0].transition(Pointer_stringify($1));
+ 	    var transition = js.objects[$0].transition(UTF8ToString($1));
 	    js.objects[$2] = transition;
       }, this->id, name.c_str(), new_id);
 
@@ -1473,7 +1473,7 @@ namespace D3 {
     /// Interrupt the transition with the name [name] on the current selection
     Selection& Interrupt(std::string name=""){
       EM_ASM_ARGS({
-	    js.objects[$0].interrupt(Pointer_stringify($1));
+	    js.objects[$0].interrupt(UTF8ToString($1));
  	  }, this->id, name.c_str());
       return *this;
     }
@@ -1534,7 +1534,7 @@ namespace D3 {
 
       // Check that the listener is valid
       emp_assert(EM_ASM_INT({
-        var func_string = Pointer_stringify($0);
+        var func_string = UTF8ToString($0);
         if (func_string == "null") {
           return true;
         }
@@ -1553,7 +1553,7 @@ namespace D3 {
       int new_id = NextD3ID();
 
       EM_ASM_ARGS({
-	    var func_string = Pointer_stringify($2);
+	    var func_string = UTF8ToString($2);
         if (typeof window[func_string] === "function") {
           func_string = window[func_string];
         }
@@ -1564,13 +1564,13 @@ namespace D3 {
         }
 
 	    if (typeof func_string === "function") {
-	      js.objects[$0].on(Pointer_stringify($1),
+	      js.objects[$0].on(UTF8ToString($1),
 		  function(d, i){
 		     js.objects[$4] = d3.select(this);
 		     func_string(d, i, $4);},
           $3);
 	    } else {
-	      js.objects[$0].on(Pointer_stringify($1), null);
+	      js.objects[$0].on(UTF8ToString($1), null);
 	    }
 
       }, this->id, type.c_str(), listener.c_str(), capture, new_id);
@@ -1589,7 +1589,7 @@ namespace D3 {
       int new_id = NextD3ID();
 
       EM_ASM_ARGS({
-	      js.objects[$0].on(Pointer_stringify($1),
+	      js.objects[$0].on(UTF8ToString($1),
 		  function(){
 		     js.objects[$4] = d3.select(this);
 		     emp.Callback($2, d, i, $4);}, $3);

--- a/source/web/d3/svg_shapes.h
+++ b/source/web/d3/svg_shapes.h
@@ -102,10 +102,10 @@ namespace D3 {
     void SetType(std::string type){
       emp_assert (
         EM_ASM_INT({
-          return d3.symbolTypes.includes(Pointer_stringify($0)) ||
-          window[Pointer_stringify($0)] === "function" ||
-          window["d3"][Pointer_stringify($0)] === "function" ||
-          window["emp"][Pointer_stringify($0)] === "function";
+          return d3.symbolTypes.includes(UTF8ToString($0)) ||
+          window[UTF8ToString($0)] === "function" ||
+          window["d3"][UTF8ToString($0)] === "function" ||
+          window["emp"][UTF8ToString($0)] === "function";
         }, type.c_str())
       );
       D3_CALLBACK_METHOD_1_ARG(type, type.c_str())

--- a/source/web/d3/utils.h
+++ b/source/web/d3/utils.h
@@ -68,7 +68,7 @@
 /// callback function or a normal string
 #define D3_CALLBACK_FUNCTION_1_ARG(FUNC, CALLBACK)                             \
   EM_ASM_ARGS({                                                                \
-      var func_string = Pointer_stringify($0);                                 \
+      var func_string = UTF8ToString($0);                                 \
       CONVERT_FUNCSTRING_TO_FUNCTION_IF_IN_NAMESPACE_OR_WINDOW("d3", "emp");   \
       emp.__new_object = FUNC(func_string);                                    \
     }, CALLBACK);
@@ -77,8 +77,8 @@
 /// before the callback function in the call to FUNC
 #define D3_CALLBACK_FUNCTION_2_ARGS(FUNC, CALLBACK, ARG1)                      \
   EM_ASM_ARGS({                                                                \
-      var arg1 = Pointer_stringify($0);                                        \
-      var func_string = Pointer_stringify($1);                                 \
+      var arg1 = UTF8ToString($0);                                        \
+      var func_string = UTF8ToString($1);                                 \
       CONVERT_FUNCSTRING_TO_FUNCTION_IF_IN_NAMESPACE_OR_WINDOW("d3", "emp");   \
       emp.__new_object = FUNC(arg1, func_string);                              \
     }, ARG1, CALLBACK);
@@ -88,8 +88,8 @@
 //Layer of indirection so macro gets expanded
 #define D3_CALLBACK_METHOD_2_ARGS_IMPL(MACRO, FUNC, ARG1, ARG2)     \
   EM_ASM_ARGS({                                                     \
-      var arg1 = Pointer_stringify($1);                             \
-      var func_string = Pointer_stringify($2);                      \
+      var arg1 = UTF8ToString($1);                             \
+      var func_string = UTF8ToString($2);                      \
       MACRO;                                                        \
       emp.__new_object = js.objects[$0].FUNC(arg1, func_string);    \
   }, this->id, ARG1, ARG2);
@@ -104,7 +104,7 @@
 //Layer of indirection so macro gets expanded
 #define D3_CALLBACK_METHOD_1_ARG_IMPL(MACRO, FUNC, ARG1)    \
 EM_ASM_ARGS({                                               \
-    var func_string = Pointer_stringify($1);                \
+    var func_string = UTF8ToString($1);                \
     MACRO;                                                  \
     emp.__new_object = js.objects[$0].FUNC(func_string);    \
 }, this->id, ARG1);
@@ -120,7 +120,7 @@ D3_CALLBACK_METHOD_1_ARG_IMPL(CONVERT_FUNCSTRING_TO_FUNCTION_IF_IN_NAMESPACE_OR_
 #define D3_CALLBACK_METHOD_CPP_FUNCTION_2_ARGS(FUNC, ARG1, CPP_FUN)        \
   uint32_t fun_id = emp::JSWrap(CPP_FUN, "", false);                       \
   EM_ASM_ARGS({                                                            \
-    emp.__new_object = js.objects[$0].FUNC(Pointer_stringify($1),          \
+    emp.__new_object = js.objects[$0].FUNC(UTF8ToString($1),          \
                                     function(d, i, j) {                    \
                                       return emp.Callback($2, d, i, j);    \
                                     });                                    \

--- a/source/web/d3/visualizations.h
+++ b/source/web/d3/visualizations.h
@@ -142,7 +142,7 @@ public:
   }
 
   void CallDrawCallback() {
-    EM_ASM_ARGS({window["emp"][Pointer_stringify($0)]()}, draw_data_callback.c_str());
+    EM_ASM_ARGS({window["emp"][UTF8ToString($0)]()}, draw_data_callback.c_str());
   }
 
   /*
@@ -479,7 +479,7 @@ public:
     return_x = [func](DATA_TYPE d){
       emp::StoreReturn(d);
       return EM_ASM_DOUBLE({
-        var func_string = Pointer_stringify($0);
+        var func_string = UTF8ToString($0);
         if (typeof window[func_string] === function) {
           func_string = window[func_string];
         } else if (typeof window["emp"][func_string] === function) {
@@ -517,7 +517,7 @@ public:
     return_y = [func](DATA_TYPE d){
       emp::StoreReturn(d);
       return EM_ASM_DOUBLE({
-        var func_string = Pointer_stringify($0);
+        var func_string = UTF8ToString($0);
         if (typeof window[func_string] === function) {
           func_string = window[func_string];
         } else if (typeof window["emp"][func_string] === function) {
@@ -540,19 +540,19 @@ public:
 
     // Adjust axes
     x_min = std::min(EM_ASM_DOUBLE({
-        return d3.min(js.objects[$0], window["emp"][Pointer_stringify($1)+"return_x"]);
+        return d3.min(js.objects[$0], window["emp"][UTF8ToString($1)+"return_x"]);
     }, dataset->GetID(), this->GetID().c_str()), x_min);
 
     x_max = std::max(EM_ASM_DOUBLE({
-        return d3.max(js.objects[$0], window["emp"][Pointer_stringify($1)+"return_x"]);
+        return d3.max(js.objects[$0], window["emp"][UTF8ToString($1)+"return_x"]);
     }, dataset->GetID(), this->GetID().c_str()), x_max);
 
     y_min = std::min(EM_ASM_DOUBLE({
-        return d3.min(js.objects[$0], window["emp"][Pointer_stringify($1)+"return_y"]);
+        return d3.min(js.objects[$0], window["emp"][UTF8ToString($1)+"return_y"]);
     }, dataset->GetID(), this->GetID().c_str()), y_min);
 
     y_max = std::max(EM_ASM_DOUBLE({
-        return d3.max(js.objects[$0], window["emp"][Pointer_stringify($1)+"return_y"]);
+        return d3.max(js.objects[$0], window["emp"][UTF8ToString($1)+"return_y"]);
     }, dataset->GetID(), this->GetID().c_str()), y_max);
 
     y_scale->SetDomain(y_max, y_min);
@@ -688,8 +688,8 @@ public:
       var s = js.objects[$0].selectAll(".line-seg").data([circle_data]);
       js.objects[$3] = s.exit();
       js.objects[$2].ease(d3.easeLinear).duration(300).selectAll(".data-point")
-                    .attr("cy", emp[Pointer_stringify($4)+"y"])
-                    .attr("cx", emp[Pointer_stringify($4)+"x"]);
+                    .attr("cy", emp[UTF8ToString($4)+"y"])
+                    .attr("cx", emp[UTF8ToString($4)+"x"]);
       t = s.transition(js.objects[$2]).duration(300).attrTween("d", pathTween).ease(d3.easeLinear);
       t.attr("d", js.objects[$1]);
       js.objects[$3]

--- a/source/web/emfunctions.h
+++ b/source/web/emfunctions.h
@@ -61,14 +61,14 @@ namespace emp {
   /// Set the background color of this web page.
   static void SetBackgroundColor(const std::string color) {
     EM_ASM_ARGS({
-        var color = Pointer_stringify($0);
+        var color = UTF8ToString($0);
         $("body").first().css("background-color", color);
       }, color.c_str());
   }
 
   static void SetColor(const std::string color) {
     EM_ASM_ARGS({
-        var color = Pointer_stringify($0);
+        var color = UTF8ToString($0);
         $("body").first().css("color", color);
       }, color.c_str());
   }
@@ -76,14 +76,14 @@ namespace emp {
   // These may already be in HTML5 for Emscripten
   static void SetCursor(const char * type) {
     EM_ASM_ARGS({
-        var type = Pointer_stringify($0);
+        var type = UTF8ToString($0);
         document.body.style.cursor = type;
     }, type);
   }
 
   static void OpenWindow(const std::string & url) {
     EM_ASM_ARGS({
-        var url = Pointer_stringify($0);
+        var url = UTF8ToString($0);
         window.open = url;
     }, url.c_str());
   }
@@ -107,7 +107,7 @@ namespace emp {
     /// Get the value of @param attribute in the element with @param id as its id. 
     inline std::string GetElementAttribute(const std::string & id, const std::string & attribute) { 
       char * buffer = (char * )EM_ASM_INT({
-        var text = document.getElementById(Pointer_stringify($0))[Pointer_stringify($1)];
+        var text = document.getElementById(UTF8ToString($0))[UTF8ToString($1)];
         var buffer = Module._malloc(text.length+1);
         Module.stringToUTF8(text, buffer, text.length*4+1);
         return buffer;

--- a/source/web/emfunctions.h
+++ b/source/web/emfunctions.h
@@ -104,8 +104,8 @@ namespace emp {
     return html.str();
   }
 
-    /// Get the value of @param attribute in the element with @param id as its id. 
-    inline std::string GetElementAttribute(const std::string & id, const std::string & attribute) { 
+    /// Get the value of @param attribute in the element with @param id as its id.
+    inline std::string GetElementAttribute(const std::string & id, const std::string & attribute) {
       char * buffer = (char * )EM_ASM_INT({
         var text = document.getElementById(UTF8ToString($0))[UTF8ToString($1)];
         var buffer = Module._malloc(text.length+1);

--- a/source/web/js_utils.h
+++ b/source/web/js_utils.h
@@ -104,7 +104,7 @@ namespace emp {
 
     	// Iterate over array, get values, and add them to incoming array.
     	for (i=0; i<$1; i++) {
-    	  curr_array.push(getValue($0+(i*$2), Pointer_stringify($3)));
+        curr_array.push(getValue($0+(i*$2), UTF8ToString($3)));
     	}
     }, &values[0], values.size(), type_size, type_string.c_str(), recursive_el.data());
   }
@@ -135,7 +135,7 @@ namespace emp {
     for (auto val : values) {
       (void) val;
       EM_ASM_ARGS({
-        emp_i.__curr_array.push(Pointer_stringify($0));
+        emp_i.__curr_array.push(UTF8ToString($0));
       }, val.c_str());
     };
 
@@ -194,10 +194,10 @@ namespace emp {
     	      curr_array = curr_array[next_index];
     	    }
 
-    	    if (Pointer_stringify($1) == "string") {
-    	      curr_array[$3][Pointer_stringify($2)] = Pointer_stringify($0);
+    	    if (UTF8ToString($1) == "string") {
+    	      curr_array[$3][UTF8ToString($2)] = UTF8ToString($0);
     	    } else {
-    	      curr_array[$3][Pointer_stringify($2)] = getValue($0, Pointer_stringify($1));
+    	      curr_array[$3][UTF8ToString($2)] = getValue($0, UTF8ToString($1));
     	    }
     	  }, values[j].pointers[i], type_string.c_str(), var_name.c_str(),
     	  j, recursive_el.data());
@@ -314,7 +314,7 @@ namespace emp {
     	var buffer = Module._malloc(emp_i.__outgoing_array.length*$0);
 
     	for (i=0; i<emp_i.__outgoing_array.length; i++) {
-    	  setValue(buffer+(i*$0), emp_i.__outgoing_array[i], Pointer_stringify($1));
+    	  setValue(buffer+(i*$0), emp_i.__outgoing_array[i], UTF8ToString($1));
     	}
 
       return buffer;
@@ -345,7 +345,7 @@ namespace emp {
     	var buffer = Module._malloc(emp_i.__outgoing_array.length*$0);
 
     	for (i=0; i<emp_i.__outgoing_array.length; i++) {
-    	  setValue(buffer+(i*$0), emp_i.__outgoing_array[i], Pointer_stringify($1));
+    	  setValue(buffer+(i*$0), emp_i.__outgoing_array[i], UTF8ToString($1));
     	}
 
     	return buffer;
@@ -379,7 +379,7 @@ namespace emp {
   //       var buffer = Module._malloc(emp_i.__outgoing_array.length*$0);
   //
   //       for (i=0; i<emp_i.__outgoing_array.length; i++) {
-  //         setValue(buffer+(i*$0), emp_i.__outgoing_array[i], Pointer_stringify($1));
+  //         setValue(buffer+(i*$0), emp_i.__outgoing_array[i], UTF8ToString($1));
   //       }
   //
   //       return buffer;


### PR DESCRIPTION
This change is necessary to track changes in emscripten, where `Pointer_stringify` has been depricated.

Closes #218.

Also, strip some trailing whitespace.