### PR TITLE
Add Parser for Url Query Params

### DIFF
--- a/source/web/UrlParams.h
+++ b/source/web/UrlParams.h
@@ -1,0 +1,46 @@
+/**
+ *  @note This file is part of Empirical, https://github.com/devosoft/Empirical
+ *  @copyright Copyright (C) Michigan State University, MIT Software license; see doc/LICENSE.md
+ *  @date 2019
+ *
+ *  @file  UrlParams.h
+ *  @brief Get an unordered_map containing url query key/value parameters.
+ *
+ */
+
+#ifndef EMP_WEB_UrlParams_H
+#define EMP_WEB_UrlParams_H
+
+#include <unordered_map>
+#include <string>
+
+#include "js_utils.h"
+
+namespace emp {
+namespace web {
+
+  std::unordered_map<std::string, std::string> GetUrlParams() {
+
+    emp::vector<emp::vector<std::string>> incoming;
+
+    EM_ASM({
+      const params = new URLSearchParams(location.search);
+      emp_i.__outgoing_array = [... params.keys()].map(
+        function(x) { return [x, params.get(x)]; }
+      );
+    });
+
+    emp::pass_vector_to_cpp(incoming);
+
+    std::unordered_map<std::string, std::string> res;
+
+    for (const auto & pair : incoming) res[pair[0]] = pair[1];
+
+    return res;
+
+  }
+
+}
+}
+
+#endif

--- a/source/web/UrlParams.h
+++ b/source/web/UrlParams.h
@@ -29,9 +29,14 @@ namespace web {
       emp_i.__outgoing_array = Array.from(
         params.entries()
       ).map(
+        p => p[0].replace(" ", "").length == 0
+          ?  ["_illegal", "_empty" + " " + p[1]] : p
+      ).map(
         p => p[0].includes(" ") ? ["_illegal", p[0] + " " + p[1]] : p
       ).map(
-        p => [p[0]].concat(p[1].split(" ")).filter(w => w.length > 0)
+        p => [p[0]].concat(p[1].split(" "))
+      ).map(
+        p => p.filter(w => w.length > 0)
       );
     });
 

--- a/source/web/UrlParams.h
+++ b/source/web/UrlParams.h
@@ -14,6 +14,7 @@
 #include <unordered_map>
 #include <string>
 
+#include "JSWrap.h"
 #include "js_utils.h"
 
 namespace emp {

--- a/source/web/UrlParams.h
+++ b/source/web/UrlParams.h
@@ -28,8 +28,8 @@ namespace web {
       const params = new URLSearchParams(location.search);
       emp_i.__outgoing_array = Array.from(
         params.entries()
-      ).filter(
-        p => !p[0].includes(" ")
+      ).map(
+        p => p[0].includes(" ") ? ["_illegal", p[0] + " " + p[1]] : p
       ).map(
         p => [p[0]].concat(p[1].split(" ")).filter(w => w.length > 0)
       );

--- a/source/web/js_utils.h
+++ b/source/web/js_utils.h
@@ -555,7 +555,6 @@ namespace emp {
     if (recurse == 0) {
       EM_ASM({
         emp_i.__temp_array = [emp_i.__outgoing_array];
-        console.log(emp_i.__outgoing_array);
       });
     } else {
       // This is a little wasteful of space, but the alternatives are

--- a/tests/web/GetUrlParams.cc
+++ b/tests/web/GetUrlParams.cc
@@ -16,7 +16,6 @@ int main() {
 
   emp::Initialize();
 
-  //TODO ++
   EM_ASM({
     global.location = Object();
     global.location.search = (

--- a/tests/web/GetUrlParams.cc
+++ b/tests/web/GetUrlParams.cc
@@ -1,0 +1,30 @@
+//  This file is part of Empirical, https://github.com/devosoft/Empirical
+//  Copyright (C) Michigan State University, 2015-2019.
+//  Released under the MIT Software license; see doc/LICENSE
+#include <functional>
+
+#include "../../tests2/unit_tests.h"
+#include "base/assert.h"
+#include "web/init.h"
+#include "web/JSWrap.h"
+
+#include "base/assert.h"
+#include "web/UrlParams.h"
+
+int main() {
+
+  emp::Initialize();
+
+  EM_ASM({
+    global.location = Object();
+    global.location.search = "test1=result&test2=result&test3=123&test1=nope";
+  });
+
+  const auto params = emp::web::GetUrlParams();
+  emp_assert(params.find("test1")->second == "result");
+  emp_assert(params.find("test2")->second == "result");
+  emp_assert(params.find("test3")->second == "123");
+  emp_assert(params.find("nope") == params.end());
+  std::cout << "Success!" << std::endl;
+  
+}

--- a/tests/web/GetUrlParams.cc
+++ b/tests/web/GetUrlParams.cc
@@ -20,10 +20,13 @@ int main() {
     global.location = Object();
     global.location.search = (
       "test1=val1" +
+      "&test4" +
       "&test2=val1" +
       "&test3=1+23" +
       "&test1=val2+val3" +
-      "&test4"
+      "&_positional=p1+p2" +
+      "&_positional=p3" +
+      "&bad+bad=gone"
     );
   });
 
@@ -42,6 +45,13 @@ int main() {
 
   emp_assert(*am.UseArg("test4") == emp::vector<std::string>());
   emp_assert(!am.UseArg("test4"));
+
+  emp_assert(
+    *am.UseArg("_positional") == emp::vector<std::string>({"p1","p2","p3"})
+  );
+  emp_assert(!am.UseArg("_positional"));
+
+  emp_assert(!am.UseArg("bad bad"));
 
   std::cout << "Success!" << std::endl;
 

--- a/tests/web/GetUrlParams.cc
+++ b/tests/web/GetUrlParams.cc
@@ -16,25 +16,35 @@ int main() {
 
   emp::Initialize();
 
+  //TODO ++
   EM_ASM({
     global.location = Object();
     global.location.search = (
       "test1=val1" +
       "&test4" +
-      "&test2=val1" +
+      "&test2=++val1" +
       "&test3=1+23" +
+      "&=bad" +
+      "&=" +
+      "&+=" +
+      "&=+" +
+      "&+=+" +
       "&test1=val2+val3" +
-      "&_positional=p1+p2" +
-      "&_positional=p3" +
-      "&bad+bad=gone"
+      "&_positional=p1++p2" +
+      "&_positional=p3+" +
+      "&bad+bad=illegal" +
+      "&bad++bad=illegal" +
+      "&+bad=illegal" +
+      "&bad+=illegal"
     );
   });
 
   emp::ArgManager am(emp::web::GetUrlParams());
 
+  am.PrintDiagnostic();
 
   emp_assert(*am.UseArg("test1") == emp::vector<std::string>({"val1"}));
-  emp_assert(*am.UseArg("test1") ==  emp::vector<std::string>({"val2","val3"}));
+  emp_assert(*am.UseArg("test1") == emp::vector<std::string>({"val2","val3"}));
   emp_assert(!am.UseArg("test1"));
 
   emp_assert(*am.UseArg("test2") == emp::vector<std::string>({"val1"}));
@@ -52,7 +62,31 @@ int main() {
   emp_assert(!am.UseArg("_positional"));
 
   emp_assert(
-    *am.UseArg("_illegal") == emp::vector<std::string>({"bad","bad","gone"})
+    *am.UseArg("_illegal") == emp::vector<std::string>({"_empty", "bad"})
+  );
+  emp_assert(
+    *am.UseArg("_illegal") == emp::vector<std::string>({"_empty"})
+  );
+  emp_assert(
+    *am.UseArg("_illegal") == emp::vector<std::string>({"_empty"})
+  );
+  emp_assert(
+    *am.UseArg("_illegal") == emp::vector<std::string>({"_empty"})
+  );
+  emp_assert(
+    *am.UseArg("_illegal") == emp::vector<std::string>({"_empty"})
+  );
+  emp_assert(
+    *am.UseArg("_illegal") == emp::vector<std::string>({"bad","bad","illegal"})
+  );
+  emp_assert(
+    *am.UseArg("_illegal") == emp::vector<std::string>({"bad","bad","illegal"})
+  );
+  emp_assert(
+    *am.UseArg("_illegal") == emp::vector<std::string>({"bad","illegal"})
+  );
+  emp_assert(
+    *am.UseArg("_illegal") == emp::vector<std::string>({"bad","illegal"})
   );
   emp_assert(!am.UseArg("_illegal"));
 

--- a/tests/web/GetUrlParams.cc
+++ b/tests/web/GetUrlParams.cc
@@ -51,7 +51,10 @@ int main() {
   );
   emp_assert(!am.UseArg("_positional"));
 
-  emp_assert(!am.UseArg("bad bad"));
+  emp_assert(
+    *am.UseArg("_illegal") == emp::vector<std::string>({"bad","bad","gone"})
+  );
+  emp_assert(!am.UseArg("_illegal"));
 
   std::cout << "Success!" << std::endl;
 

--- a/tests/web/GetUrlParams.cc
+++ b/tests/web/GetUrlParams.cc
@@ -10,6 +10,7 @@
 
 #include "base/assert.h"
 #include "web/UrlParams.h"
+#include "config/ArgManager.h"
 
 int main() {
 
@@ -17,14 +18,31 @@ int main() {
 
   EM_ASM({
     global.location = Object();
-    global.location.search = "test1=result&test2=result&test3=123&test1=nope";
+    global.location.search = (
+      "test1=val1" +
+      "&test2=val1" +
+      "&test3=1+23" +
+      "&test1=val2+val3" +
+      "&test4"
+    );
   });
 
-  const auto params = emp::web::GetUrlParams();
-  emp_assert(params.find("test1")->second == "result");
-  emp_assert(params.find("test2")->second == "result");
-  emp_assert(params.find("test3")->second == "123");
-  emp_assert(params.find("nope") == params.end());
+  emp::ArgManager am(emp::web::GetUrlParams());
+
+
+  emp_assert(*am.UseArg("test1") == emp::vector<std::string>({"val1"}));
+  emp_assert(*am.UseArg("test1") ==  emp::vector<std::string>({"val2","val3"}));
+  emp_assert(!am.UseArg("test1"));
+
+  emp_assert(*am.UseArg("test2") == emp::vector<std::string>({"val1"}));
+  emp_assert(!am.UseArg("test2"));
+
+  emp_assert(am.UseArg("test3") == emp::vector<std::string>({"1","23"}));
+  emp_assert(!am.UseArg("test3"));
+
+  emp_assert(*am.UseArg("test4") == emp::vector<std::string>());
+  emp_assert(!am.UseArg("test4"));
+
   std::cout << "Success!" << std::endl;
-  
+
 }

--- a/tests/web/Makefile
+++ b/tests/web/Makefile
@@ -16,13 +16,16 @@ OFLAGS_web_braces := -g4 -pedantic -Wno-dollar-in-identifier-extension -s TOTAL_
 CFLAGS_web := $(CFLAGS_all) $(OFLAGS_web_braces) --js-library ../../source/web/library_emp.js --js-library ../../source/web/d3/library_d3.js -s EXPORTED_FUNCTIONS="['_main', '_empCppCallback']" -s DISABLE_EXCEPTION_CATCHING=1 -s NO_EXIT_RUNTIME=1 -s EXTRA_EXPORTED_RUNTIME_METHODS='["ccall", "cwrap"]' -s WASM=0
 
 default: all
-all: JSWrap.js js_utils.js test_visualizations.js color_map
+all: GetUrlParams.js JSWrap.js js_utils.js test_visualizations.js color_map
 
 color_map: color_map.cc
 	g++ $(CFLAGS_all) color_map.cc -o color_map
 
 JSWrap.js: JSWrap.cc
 	$(CXX_web) $(CFLAGS_web) JSWrap.cc -o JSWrap.js
+
+GetUrlParams.js: GetUrlParams.cc
+	$(CXX_web) $(CFLAGS_web) GetUrlParams.cc -o GetUrlParams.js
 
 js_utils.js: js_utils.cc
 	$(CXX_web) $(CFLAGS_web) js_utils.cc -o js_utils.js

--- a/tests/web/Makefile
+++ b/tests/web/Makefile
@@ -34,7 +34,7 @@ test_visualizations.js: test_visualizations.cc
 	$(CXX_web) $(CFLAGS_web) test_visualizations.cc -o test_visualizations.js
 
 clean:
-	rm -f JSWrap.js js_utils.js test_visualizations.js *.js.map *.js.mem *~ color_map
+	rm -f GetUrlParams.js JSWrap.js js_utils.js test_visualizations.js *.js.map *.js.mem *~ color_map
 
 # Debugging information
 #print-%: ; @echo $*=$($*)

--- a/tests/web/run_tests.sh
+++ b/tests/web/run_tests.sh
@@ -3,7 +3,7 @@ echo "Source loaded"
 make
 echo "compilation done"
 ./color_map
-for filename in js_utils.js JSWrap.js;
+for filename in js_utils.js JSWrap.js GetUrlParams.js;
 do
     node $filename;
     if [ $? -gt 0 ];


### PR DESCRIPTION
Let's make it easy to snag the query params of the current web page over to the C++ side of things!

(background info: https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams/URLSearchParams)

usage example:
```
#include <unordered_map>

#include "web/web.h"
#include "web/UrlParams.h"

namespace UI = emp::web;

UI::Document doc("emp_base");

int main()
{

  auto params = UI::GetUrlParams();

  for(auto & pair : params) {
    std::cout << pair.first << " -> " << pair.second << std::endl;
  }

}
```

For example, browsing to `https://example.com/example.html?foo=bar&bip=bop` would cause to the following to be output to the console.

```
bip -> bop
foo -> bar
```