### PR TITLE
Rewrite ArgManager

### DIFF
--- a/source/config/ArgManager.h
+++ b/source/config/ArgManager.h
@@ -223,31 +223,6 @@ namespace emp {
       return res;
     }
 
-    // create best-effort specifications for unspecified Args
-    static std::unordered_map<std::string, ArgSpec> retrofit_specs(
-      const std::multimap<std::string, emp::vector<std::string>> & packs
-    ) {
-
-      std::unordered_map<std::string, ArgSpec> res;
-
-      for (const auto & [n, p] : packs) {
-        if (!res.count(n)) {
-          res.insert({
-            n,
-            ArgSpec(
-              0,
-              "Retrofitted.",
-              {},
-              false
-            )
-          });
-        }
-      }
-
-      return res;
-
-    }
-
     ArgManager(
       int argc,
       char* argv[],
@@ -268,7 +243,7 @@ namespace emp {
     ArgManager(
       const std::multimap<std::string, emp::vector<std::string>> & packs_,
       const std::unordered_map<std::string, ArgSpec> & specs_ = std::unordered_map<std::string, ArgSpec>()
-    ) : packs(packs_), specs(specs_.size() ? specs_ : retrofit_specs(packs_)) {
+    ) : packs(packs_), specs(specs_) {
 
       // flatten args that should be flattened
       for (auto & [n, s] : specs) {

--- a/source/config/ArgManager.h
+++ b/source/config/ArgManager.h
@@ -362,7 +362,7 @@ namespace emp {
     /// packs are consumed.
     void UseCallbacks() {
 
-      for (const auto &[name, [[maybe_unused]] spec]: specs) {
+      for (const auto &[name, spec]: specs) {
         while (CallbackArg(name));
       }
 

--- a/source/config/ArgManager.h
+++ b/source/config/ArgManager.h
@@ -343,6 +343,12 @@ namespace emp {
         return false;
       }
 
+      if (const auto res = ViewArg("_unknown"); res.size()) {
+        PrintDiagnostic(os);
+        PrintHelp(os);
+        return false;
+      }
+
       bool proceed = true;
 
       if (const auto res = UseArg("gen"); res && config) {

--- a/source/config/ArgManager.h
+++ b/source/config/ArgManager.h
@@ -526,7 +526,7 @@ namespace emp {
         if (spec.least_quota == spec.most_quota) {
           os << " [ quota = " << spec.most_quota << " ]";
         } else {
-          os << " [ " << spec.least_quota << "<= quota <= "
+          os << " [ " << spec.least_quota << " <= quota <= "
             << spec.most_quota << " ]";
         }
         os << std::endl

--- a/source/config/ArgManager.h
+++ b/source/config/ArgManager.h
@@ -86,15 +86,15 @@ namespace emp {
           size_t n = n_spec ?
             std::next(r_spec.first, n_proc % n_spec)->second : 0;
 
-          packs.insert(
-            {
-              deflagged[i],
-              emp::vector<std::string>(
-                std::next(std::begin(args), i+1),
-                std::next(std::begin(args), std::min(i+n+1,args.size()))
-              )
-            }
-          );
+          if (i+n+1 <= args.size()) packs.insert(
+              {
+                deflagged[i],
+                emp::vector<std::string>(
+                  std::next(std::begin(args), i+1),
+                  std::next(std::begin(args), i+n+1)
+                )
+              }
+            );
 
           i += n;
 

--- a/source/config/ArgManager.h
+++ b/source/config/ArgManager.h
@@ -45,13 +45,13 @@ namespace emp {
   ///   (e.g., a single list of words instead of a list of lists of words).
   struct ArgSpec {
 
-    const size_t quota;
-    const std::string description;
-    const std::unordered_set<std::string> aliases;
-    const std::function<void(std::optional<emp::vector<std::string>>)> callback;
-    const bool enforce_quota; // quota is enforced at access, not setup
-    const bool gobble_flags;
-    const bool flatten;
+    size_t most_quota;
+    size_t least_quota;
+    std::string description;
+    std::unordered_set<std::string> aliases;
+    std::function<void(std::optional<emp::vector<std::string>>)> callback;
+    bool gobble_flags;
+    bool flatten;
 
     ArgSpec(
       const size_t quota_=0,

--- a/source/config/ArgManager.h
+++ b/source/config/ArgManager.h
@@ -20,17 +20,17 @@ namespace emp {
     /// A simple class to manage command-line arguments that were passed in.
     /// Derived from emp::vector<std::string>, but with added functionality for argument handling.
     class [[deprecated("emp::cl::ArgManager has been replaced by"
-      "emp::ArgManager, which has API updates")]] ArgManager {
+      "emp::ArgManager, which has API updates")]]
+      ArgManager : public emp::vector<std::string> {
     private:
-      emp::vector<std::string> unprocessed;
-
+      using parent_t = emp::vector<std::string>;
       emp::vector<std::string> arg_names;
       emp::vector<std::string> arg_descs;
 
     public:
-      ArgManager() : arg_names(), arg_descs() { ; }
+      ArgManager() : parent_t(), arg_names(), arg_descs() { ; }
       ArgManager(int argc, char* argv[])
-       : unprocessed(args_to_strings(argc, argv)), arg_names(), arg_descs() { ; }
+       : parent_t(args_to_strings(argc, argv)), arg_names(), arg_descs() { ; }
       ~ArgManager() { ; }
 
       /// UseArg takes a name, a variable and an optional description.  If the name exists,
@@ -40,7 +40,7 @@ namespace emp {
       int UseArg(const std::string & name, T & var, const std::string & desc="") {
         arg_names.push_back(name);
         arg_descs.push_back(desc);
-        return use_arg_value(unprocessed, name, var);
+        return use_arg_value(*this, name, var);
       }
 
       /// UseArg can also take a config object and a name, and use the argument to set the
@@ -50,7 +50,7 @@ namespace emp {
         arg_names.push_back(name);
         arg_descs.push_back(desc);
         std::string var;
-        bool rv = use_arg_value(unprocessed, name, var);
+        bool rv = use_arg_value(*this, name, var);
         if (rv==1) config.Set(cfg_name, var);
         return rv;
       }
@@ -60,7 +60,7 @@ namespace emp {
       bool UseFlag(const std::string & name, const std::string & desc="") {
         arg_names.push_back(name);
         arg_descs.push_back(desc);
-        return use_arg(unprocessed, name);
+        return use_arg(*this, name);
       }
 
       /// Print information about all known argument types and what they're for; make pretty.
@@ -79,9 +79,9 @@ namespace emp {
 
       /// Test if there are any unprocessed arguments, and if so, output an error.
       bool HasUnknown(std::ostream & os=std::cerr) const {
-        if (unprocessed.size() > 1) {
+        if (size() > 1) {
           os << "Unknown args:";
-          for (size_t i = 1; i < unprocessed.size(); i++) os << " " << unprocessed[i];
+          for (size_t i = 1; i < size(); i++) os << " " << (*this)[i];
           os << std::endl;
           PrintHelp(os);
           return true;

--- a/source/config/ArgManager.h
+++ b/source/config/ArgManager.h
@@ -424,7 +424,7 @@ namespace emp {
 
     /// ViewArg provides, but doesn't comsume,
     /// all argument packs under a certain name.
-    emp::vector<emp::vector<std::string>> ViewArg(const std::string & name) {
+    emp::vector<emp::vector<std::string>> ViewArg(const std::string & name) const {
 
       emp::vector<emp::vector<std::string>> res;
 

--- a/source/config/ArgManager.h
+++ b/source/config/ArgManager.h
@@ -18,6 +18,7 @@
 #include <limits>
 #include <numeric>
 #include <cstdlib>
+#include <optional>
 
 #include "base/Ptr.h"
 #include "base/vector.h"

--- a/source/config/ArgManager.h
+++ b/source/config/ArgManager.h
@@ -374,15 +374,23 @@ namespace emp {
     /// make pretty.
     void PrintHelp(std::ostream & os=std::cerr) const {
 
-      for (const auto & [n, s] : specs) {
-        os << "-"
-           << n;
-        for (const auto & a : s.aliases) os << " -" << a;
-        os << " [" << ( (!s.enforce_quota) ? "<=" : "=" ) << s.quota << "]";
+      os << "Usage:" << std::endl;
+      // print arguments in alphabetical order
+      for (
+        const auto & [name, spec]
+        : std::map<std::string,ArgSpec>(std::begin(specs), std::end(specs))
+      ) {
+        if (name != "_unknown" && name != "_positional") os << "-";
+        os << name;
+        for (const auto & alias : spec.aliases) os << " -" << alias;
+        os << " [ quota "
+          << ( (!spec.enforce_quota) ? "<=" : "=" ) << " "
+          << spec.quota
+          << " ]";
         os << std::endl
-           << "   | "
-           << s.description
-           << std::endl;
+          << "   | "
+          << spec.description
+          << std::endl;
 
       }
 

--- a/source/config/ArgManager.h
+++ b/source/config/ArgManager.h
@@ -362,7 +362,7 @@ namespace emp {
     /// packs are consumed.
     void UseCallbacks() {
 
-      for (const auto &[name, spec]: specs) {
+      for (const auto &[name, [[maybe_unused]] spec]: specs) {
         while (CallbackArg(name));
       }
 

--- a/source/config/ArgManager.h
+++ b/source/config/ArgManager.h
@@ -208,7 +208,7 @@ namespace emp {
 
     /// Make specs for builtin commands, including any config adjustment args.
     static std::unordered_map<std::string, ArgSpec> make_builtin_specs(
-      const emp::Ptr<const Config> config=nullptr
+      const emp::Ptr<Config> config=nullptr
     ) {
 
       std::unordered_map<std::string, ArgSpec> res({
@@ -273,7 +273,13 @@ namespace emp {
                 entry->GetDescription(),
                 " (type=", entry->GetType(),
                 "; default=", entry->GetDefault(), ')'
-              )
+              ),
+              {},
+              [config, entry](std::optional<emp::vector<std::string>> res){
+                if (res && config) {
+                  config->Set(entry->GetName(), res->front());
+                }
+              }
             )
           });
         }

--- a/source/config/ArgManager.h
+++ b/source/config/ArgManager.h
@@ -385,7 +385,7 @@ namespace emp {
 
     /// Test if there are any unused arguments, and if so, output an error.
     bool HasUnused(std::ostream & os=std::cerr) const {
-      if (packs.size() > 1) {
+      if (packs.size()) {
         Print(os);
         PrintHelp(os);
         return true;

--- a/source/config/ArgManager.h
+++ b/source/config/ArgManager.h
@@ -263,7 +263,7 @@ namespace emp {
     ArgManager(
       int argc,
       char* argv[],
-      const std::unordered_map<std::string, ArgSpec> & specs_ = std::unordered_map<std::string, ArgSpec>()
+      const std::unordered_map<std::string, ArgSpec> & specs_ = make_builtin_specs()
     ) : ArgManager(
       ArgManager::args_to_strings(argc, argv),
       specs_
@@ -271,7 +271,7 @@ namespace emp {
 
     ArgManager(
       const emp::vector<std::string> args,
-      const std::unordered_map<std::string, ArgSpec> & specs_ = std::unordered_map<std::string, ArgSpec>()
+      const std::unordered_map<std::string, ArgSpec> & specs_ = make_builtin_specs()
     ) : ArgManager(
       ArgManager::parse(args, specs_),
       specs_
@@ -279,7 +279,7 @@ namespace emp {
 
     ArgManager(
       const std::multimap<std::string, emp::vector<std::string>> & packs_,
-      const std::unordered_map<std::string, ArgSpec> & specs_ = std::unordered_map<std::string, ArgSpec>()
+      const std::unordered_map<std::string, ArgSpec> & specs_ = make_builtin_specs()
     ) : packs(packs_), specs(specs_) {
 
       // flatten args that should be flattened

--- a/source/config/ArgManager.h
+++ b/source/config/ArgManager.h
@@ -111,7 +111,7 @@ namespace emp {
         bool const_macros  = macro_file.size() && UseFlag("--make-const", "Generate const version of macros file.");
 
         if (print_help)    { PrintHelp(os); return false; }
-        if (create_config) { 
+        if (create_config) {
           os << "Generating new config file: " << cfg_file << std::endl;
           config.Write(cfg_file);
           return false;

--- a/source/config/ArgManager.h
+++ b/source/config/ArgManager.h
@@ -333,11 +333,22 @@ namespace emp {
     }
 
     /// Print the current state of the ArgManager.
-    void Print(std::ostream & os=std::cout) const {
+    void PrintDiagnostic(std::ostream & os=std::cout) const {
 
-      for(const auto & it : packs ) {
-        os << it.first << ":";
-        for(const auto & v : it.second ) {
+      for (const auto & [name, vals] : packs) {
+        if (name == "_unknown") {
+          os << "UNKNOWN | ";
+        } else if (
+          specs.count(name)
+          && specs.find(name)->second.enforce_quota
+          && specs.find(name)->second.quota != vals.size()
+        ) {
+          os << "UNMET QUOTA | ";
+        } else {
+          os << "UNUSED | ";
+        }
+        os << name << ":";
+        for (const auto & v : vals) {
           os << " " << v;
         }
         os << std::endl;
@@ -374,7 +385,7 @@ namespace emp {
     /// Test if there are any unused arguments, and if so, output an error.
     bool HasUnused(std::ostream & os=std::cerr) const {
       if (packs.size()) {
-        Print(os);
+        PrintDiagnostic(os);
         PrintHelp(os);
         return true;
       }

--- a/source/config/ArgManager.h
+++ b/source/config/ArgManager.h
@@ -117,19 +117,19 @@ namespace emp {
       );
 
       // check for duplicate aliases
-      const bool check = alias_map.size() == std::accumulate(
-        std::begin(specs),
-        std::end(specs),
-        specs.size(),
-        [](
-          const size_t l,
-          const std::pair<std::string, ArgSpec> & r
-        ){
-          return l + r.second.aliases.size();
-        }
-      );
-
-      emp_assert(check, "duplicate aliases detected");
+      emp_assert([&](){
+        return alias_map.size() == std::accumulate(
+          std::begin(specs),
+          std::end(specs),
+          specs.size(),
+          [](
+            const size_t l,
+            const std::pair<std::string, ArgSpec> & r
+          ){
+            return l + r.second.aliases.size();
+          }
+        );
+      }(), "duplicate aliases detected");
 
       // lookup table with leading dashes stripped
       const emp::vector<std::string> deflagged = [args](){

--- a/source/config/ArgManager.h
+++ b/source/config/ArgManager.h
@@ -240,19 +240,21 @@ namespace emp {
         )}
       });
 
-      for (const auto & e : *config) {
-        const auto & entry = e.second;
-        res.insert({
-          entry->GetName(),
-          ArgSpec(
-            1,
-            emp::to_string(
-              entry->GetDescription(),
-              " (type=", entry->GetType(),
-              "; default=", entry->GetDefault(), ')'
+      if (config) {
+        for (const auto & e : *config) {
+          const auto & entry = e.second;
+          res.insert({
+            entry->GetName(),
+            ArgSpec(
+              1,
+              emp::to_string(
+                entry->GetDescription(),
+                " (type=", entry->GetType(),
+                "; default=", entry->GetDefault(), ')'
+              )
             )
-          )
-        });
+          });
+        }
       }
 
       return res;

--- a/source/config/ArgManager.h
+++ b/source/config/ArgManager.h
@@ -19,7 +19,8 @@ namespace emp {
 
     /// A simple class to manage command-line arguments that were passed in.
     /// Derived from emp::vector<std::string>, but with added functionality for argument handling.
-    class ArgManager {
+    class [[deprecated("emp::cl::ArgManager has been replaced by"
+      "emp::ArgManager, which has API updates")]] ArgManager {
     private:
       emp::vector<std::string> unprocessed;
 

--- a/source/config/ArgManager.h
+++ b/source/config/ArgManager.h
@@ -465,7 +465,6 @@ namespace emp {
     }
 
     /// Convert settings from a configure object to command-line arguments.
-    /// Return bool for "should program proceed" (i.e., true=continue, false=exit).
     void ApplyConfigOptions(Config & config) {
 
       // Scan through the config object to generate command line flags for each setting.

--- a/source/config/ArgManager.h
+++ b/source/config/ArgManager.h
@@ -193,6 +193,13 @@ namespace emp {
           false,
           true
         )},
+        {"_unknown", ArgSpec(
+          std::numeric_limits<size_t>::max(),
+          "Unknown arguments.",
+          {},
+          false,
+          false
+        )},
         {"help", ArgSpec(0, "Print help information.", {"h"})},
         {"gen", ArgSpec(1, "Generate configuration file.")},
         {"make-const", ArgSpec(1, "Generate const version of macros file.")}

--- a/source/config/ArgManager.h
+++ b/source/config/ArgManager.h
@@ -19,16 +19,17 @@ namespace emp {
 
     /// A simple class to manage command-line arguments that were passed in.
     /// Derived from emp::vector<std::string>, but with added functionality for argument handling.
-    class ArgManager : public emp::vector<std::string> {
+    class ArgManager {
     private:
-      using parent_t = emp::vector<std::string>;
+      emp::vector<std::string> unprocessed;
+
       emp::vector<std::string> arg_names;
       emp::vector<std::string> arg_descs;
 
     public:
-      ArgManager() : parent_t(), arg_names(), arg_descs() { ; }
+      ArgManager() : arg_names(), arg_descs() { ; }
       ArgManager(int argc, char* argv[])
-       : parent_t(args_to_strings(argc, argv)), arg_names(), arg_descs() { ; }
+       : unprocessed(args_to_strings(argc, argv)), arg_names(), arg_descs() { ; }
       ~ArgManager() { ; }
 
       /// UseArg takes a name, a variable and an optional description.  If the name exists,
@@ -38,7 +39,7 @@ namespace emp {
       int UseArg(const std::string & name, T & var, const std::string & desc="") {
         arg_names.push_back(name);
         arg_descs.push_back(desc);
-        return use_arg_value(*this, name, var);
+        return use_arg_value(unprocessed, name, var);
       }
 
       /// UseArg can also take a config object and a name, and use the argument to set the
@@ -48,7 +49,7 @@ namespace emp {
         arg_names.push_back(name);
         arg_descs.push_back(desc);
         std::string var;
-        bool rv = use_arg_value(*this, name, var);
+        bool rv = use_arg_value(unprocessed, name, var);
         if (rv==1) config.Set(cfg_name, var);
         return rv;
       }
@@ -58,7 +59,7 @@ namespace emp {
       bool UseFlag(const std::string & name, const std::string & desc="") {
         arg_names.push_back(name);
         arg_descs.push_back(desc);
-        return use_arg(*this, name);
+        return use_arg(unprocessed, name);
       }
 
       /// Print information about all known argument types and what they're for; make pretty.
@@ -77,9 +78,9 @@ namespace emp {
 
       /// Test if there are any unprocessed arguments, and if so, output an error.
       bool HasUnknown(std::ostream & os=std::cerr) const {
-        if (size() > 1) {
+        if (unprocessed.size() > 1) {
           os << "Unknown args:";
-          for (size_t i = 1; i < size(); i++) os << " " << (*this)[i];
+          for (size_t i = 1; i < unprocessed.size(); i++) os << " " << unprocessed[i];
           os << std::endl;
           PrintHelp(os);
           return true;

--- a/source/config/ArgManager.h
+++ b/source/config/ArgManager.h
@@ -371,7 +371,7 @@ namespace emp {
     // Process builtin commands.
     /// Return bool for "should program proceed" (i.e., true=continue, false=exit).
     bool ProcessBuiltin(
-      const emp::Ptr<const Config> config=nullptr,
+      const emp::Ptr<Config> config=nullptr,
       std::ostream & os=std::cout
     ) {
 
@@ -387,6 +387,16 @@ namespace emp {
       }
 
       bool proceed = true;
+
+      // Apply config arguments to Config object.
+      if (config) {
+        for (auto e : *config) {
+          const auto entry = e.second;
+          if (const auto res = UseArg(entry->GetName()); res) {
+            config->Set(entry->GetName(), res->front());
+          }
+        }
+      }
 
       if (const auto res = UseArg("gen"); res && config) {
         const std::string cfg_file = res->front();
@@ -464,22 +474,6 @@ namespace emp {
         return true;
       }
       return false;
-    }
-
-    /// Convert settings from a configure object to command-line arguments.
-    void ApplyConfigOptions(Config & config) {
-
-      // Scan through the config object to generate command line flags for each setting.
-      for (auto e : config) {
-
-        const auto entry = e.second;
-
-        const auto res = UseArg(entry->GetName());
-
-        if (res) config.Set(entry->GetName(), (*res)[0]);
-
-      }
-
     }
 
   };

--- a/source/config/config.h
+++ b/source/config/config.h
@@ -382,6 +382,9 @@ namespace emp {
     auto begin() -> decltype(var_map.begin()) { return var_map.begin(); }
     auto end() -> decltype(var_map.end()) { return var_map.end(); }
 
+    auto begin() const -> const decltype(var_map.begin()) { return var_map.begin(); }
+    auto end() const -> const decltype(var_map.end()) { return var_map.end(); }
+
     Config & SetExpandOK(bool ok=true) { expand_ok = ok; return *this; }
 
     bool Has(const std::string & setting_name) const {

--- a/source/config/config.h
+++ b/source/config/config.h
@@ -453,36 +453,6 @@ namespace emp {
       }
     }
 
-    /// for use with ArgManager
-    std::multimap<std::string, size_t> ArgCounts() const {
-
-      std::multimap<std::string, size_t> res;
-
-      for (const auto e : var_map) {
-        const auto entry = e.second;
-        res.insert( {entry->GetName(), 1} );
-      }
-
-      return res;
-    }
-
-    std::multimap<std::string, std::string> ArgDescriptions() const {
-
-      std::multimap<std::string, std::string> res;
-
-      for (const auto e : var_map) {
-        const auto entry = e.second;
-        const std::string desc = emp::to_string(
-          entry->GetDescription(),
-          " (type=", entry->GetType(),
-          "; default=", entry->GetDefault(), ')'
-        );
-        res.insert( {entry->GetName(), desc} );
-      }
-
-      return res;
-    }
-
     // If a string is passed into Write, treat it as a filename.
     void Write(std::string filename) const {
       std::ofstream out(filename);

--- a/source/config/config.h
+++ b/source/config/config.h
@@ -450,6 +450,36 @@ namespace emp {
       }
     }
 
+    /// for use with ArgManager
+    std::multimap<std::string, size_t> ArgCounts() const {
+
+      std::multimap<std::string, size_t> res;
+
+      for (const auto e : var_map) {
+        const auto entry = e.second;
+        res.insert( {entry->GetName(), 1} );
+      }
+
+      return res;
+    }
+
+    std::multimap<std::string, std::string> ArgDescriptions() const {
+
+      std::multimap<std::string, std::string> res;
+
+      for (const auto e : var_map) {
+        const auto entry = e.second;
+        const std::string desc = emp::to_string(
+          entry->GetDescription(),
+          " (type=", entry->GetType(),
+          "; default=", entry->GetDefault(), ')'
+        );
+        res.insert( {entry->GetName(), desc} );
+      }
+
+      return res;
+    }
+
     // If a string is passed into Write, treat it as a filename.
     void Write(std::string filename) const {
       std::ofstream out(filename);

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -32,7 +32,7 @@ test: test-prep $(addprefix test-, $(TEST_NAMES))
 	rm -rf test*.out
 
 # Test optimized version without debug features
-opt: FLAGS := -std=c++17 -DNDEBUG -O3 -Wno-unused-function -I../source/ -I../ 
+opt: FLAGS := -std=c++17 -DNDEBUG -O3 -Wno-unused-function -I../source/ -I../
 opt: test-prep $(addprefix test-, $(TEST_NAMES))
 	rm -rf test*.out
 
@@ -52,7 +52,7 @@ test-web:
 coverage_conversion:
 	  ./convert_for_tests.sh
 
-test-coverage: FLAGS := -std=c++17 -g -Wall -Wno-unused-function -I../coverage_source/ -I../ -DEMP_TRACK_MEM -Wnon-virtual-dtor -Wcast-align -Woverloaded-virtual -ftemplate-backtrace-limit=0 -fprofile-instr-generate -fcoverage-mapping -fno-inline -fno-elide-constructors -O0 
+test-coverage: FLAGS := -std=c++17 -g -Wall -Wno-unused-function -I../coverage_source/ -I../ -DEMP_TRACK_MEM -Wnon-virtual-dtor -Wcast-align -Woverloaded-virtual -ftemplate-backtrace-limit=0 -fprofile-instr-generate -fcoverage-mapping -fno-inline -fno-elide-constructors -O0
 test-coverage: coverage_conversion test-prep $(addprefix cover-test-, $(TEST_NAMES))
 	       rm -r ../coverage_source
 

--- a/tests/test_config.cc
+++ b/tests/test_config.cc
@@ -36,6 +36,29 @@ TEST_CASE("Test config", "[config]"){
 
   argv.push_back(nullptr);
 
+  {
   emp::cl::ArgManager am(argv.size() - 1, argv.data());
+  }
+
+  {
+  emp::ArgManager am(argv.size() - 1, argv.data());
+  }
+
+  {
+  emp::ArgManager am(
+    argv.size() - 1,
+    argv.data(),
+    config.ArgCounts()
+  );
+  }
+
+  {
+  emp::ArgManager am(
+    argv.size() - 1,
+    argv.data(),
+    config.ArgCounts(),
+    config.ArgDescriptions()
+  );
+  }
 
 }

--- a/tests/test_config.cc
+++ b/tests/test_config.cc
@@ -69,7 +69,10 @@ TEST_CASE("Test config", "[config]"){
     // Alternatively, we could merge in additional specifications from another unordered map:
     // std::unordered_map<std::string,emp::ArgSpec> additional_specs{"dir", emp::ArgSpec(1)};
     // specs.merge(additional_specs);
-    
+
+    // Another alternative, we can construct the key-value pair using emplace.
+    // specs.try_emplace("dir", 1);
+
     emp::ArgManager am(
       argv.size() - 1,
       argv.data(),
@@ -122,12 +125,13 @@ TEST_CASE("Test config", "[config]"){
     argv.push_back(nullptr);
 
     auto specs = emp::ArgManager::make_builtin_specs(&config);
-
-    specs.merge(std::unordered_map<std::string,emp::ArgSpec>{
-      {"dir", emp::ArgSpec(1, "some information 'n stuff", {"d"})},
-      {"duo", emp::ArgSpec(2, "two things")},
-      {"nope", emp::ArgSpec(0, "not here")}
-    });
+    specs["dir"] = emp::ArgSpec(
+      1,
+      "some information 'n stuff",
+      std::unordered_set<std::string>{"d"}
+    );
+    specs["duo"] = emp::ArgSpec(2, "two things");
+    specs["nope"] = emp::ArgSpec(0, "not here");
 
     emp::ArgManager am(
       argv.size() - 1,

--- a/tests/test_config.cc
+++ b/tests/test_config.cc
@@ -46,6 +46,7 @@ TEST_CASE("Test config", "[config]"){
 
   }
 
+  // minimal test
   {
 
     emp::vector<std::string> arguments = {"--dir", "/some_path"};
@@ -61,11 +62,20 @@ TEST_CASE("Test config", "[config]"){
       { {"dir", emp::ArgSpec(1)} }
     );
 
-    // emp::ArgManager am(
-    //   argv.size() - 1,
-    //   argv.data(),
-    //   specs
-    // );
+    emp::ArgManager am(
+      argv.size() - 1,
+      argv.data(),
+      specs
+    );
+
+    am.Print(std::cout);
+
+    REQUIRE(am.HasUnused());
+
+    REQUIRE(*am.UseArg("dir") == (emp::vector<std::string>) {"/some_path"} );
+    REQUIRE(!am.UseArg("dir"));
+
+    REQUIRE(!am.HasUnused());
 
   }
 

--- a/tests/test_config.cc
+++ b/tests/test_config.cc
@@ -8,6 +8,8 @@
 #include <iostream>
 
 #include "base/assert.h"
+#include "base/vector.h"
+#include "config/ArgManager.h"
 #include "config/command_line.h"
 #include "config/config.h"
 #include "config/config_setup.h"
@@ -26,4 +28,14 @@ TEST_CASE("Test config", "[config]"){
   std::cout << "Random seed = " << config.RANDOM_SEED() << std::endl;
 
   REQUIRE(config.RANDOM_SEED() == 123);
+
+  emp::vector<std::string> arguments = {"--dir", "/some_path"};
+
+  std::vector<char*> argv;
+  for (const auto& arg : arguments) argv.push_back((char*)arg.data());
+
+  argv.push_back(nullptr);
+
+  emp::cl::ArgManager am(argv.size() - 1, argv.data());
+
 }

--- a/tests/test_config.cc
+++ b/tests/test_config.cc
@@ -116,7 +116,11 @@ TEST_CASE("Test config", "[config]"){
       "--duo",
       "a",
       "b",
-      "pos4"
+      "pos4",
+      "--", // in POSIX, -- means treat subsequent words as literals
+      "--duo",
+      "-a",
+      "b"
     };
 
     std::vector<char*> argv;
@@ -154,7 +158,9 @@ TEST_CASE("Test config", "[config]"){
 
     REQUIRE(
       *am.UseArg("_positional")
-      == ((emp::vector<std::string>) {"pos1", "pos2", "pos3", "pos4"})
+      == ((emp::vector<std::string>) {
+        "pos1", "pos2", "pos3", "pos4", "--duo", "-a", "b"
+      })
     );
     REQUIRE(!am.UseArg("_positional"));
 

--- a/tests/test_config.cc
+++ b/tests/test_config.cc
@@ -132,12 +132,13 @@ TEST_CASE("Test config", "[config]"){
     REQUIRE(*am.UseArg("help") == (emp::vector<std::string>) {} );
     REQUIRE(!am.UseArg("help"));
 
-    emp::vector<std::string> res = {"-a", "b"};
-    REQUIRE(res == *am.UseArg("duo"));
+    REQUIRE(*am.UseArg("duo") == ((emp::vector<std::string>) {"-a", "b"}));
     REQUIRE(!am.UseArg("duo"));
 
-    res = (emp::vector<std::string>) {"pos1", "pos2"};
-    REQUIRE(*am.UseArg("_positional") == res);
+    REQUIRE(
+      *am.UseArg("_positional")
+      == ((emp::vector<std::string>) {"pos1", "pos2"})
+    );
     REQUIRE(*am.UseArg("_positional") == (emp::vector<std::string>) {"pos3"} );
     REQUIRE(*am.UseArg("_positional") == (emp::vector<std::string>) {"pos4"} );
     REQUIRE(!am.UseArg("_positional"));

--- a/tests/test_config.cc
+++ b/tests/test_config.cc
@@ -98,18 +98,18 @@ TEST_CASE("Test config", "[config]"){
 
     argv.push_back(nullptr);
 
-    auto counts = config.ArgCounts();
+    auto counts = emp::ArgManager::MakeBuiltinCounts();
+    counts.merge(config.ArgCounts());
     counts.merge( (std::multimap<std::string,size_t>) {
       {"dir", 1},
-      {"help", 0},
       {"duo", 2},
       {"nope", 0}
     });
 
-    auto descs = config.ArgDescriptions();
+    auto descs = emp::ArgManager::MakeBuiltinDescs();
+    descs.merge(config.ArgDescriptions());
     descs.merge( (std::multimap<std::string,std::string>) {
       {"dir", "some information 'n stuff"},
-      {"help", "I need somebody!"},
       {"duo", "two things"},
       {"nope", "not here"}
     });
@@ -129,8 +129,9 @@ TEST_CASE("Test config", "[config]"){
     REQUIRE(*am.UseArg("dir") == (emp::vector<std::string>) {"/other_path"} );
     REQUIRE(!am.UseArg("dir"));
 
-    REQUIRE(*am.UseArg("help") == (emp::vector<std::string>) {} );
+    REQUIRE(!am.ProcessBuiltin());
     REQUIRE(!am.UseArg("help"));
+    REQUIRE(am.ProcessBuiltin(&config));
 
     REQUIRE(*am.UseArg("duo") == ((emp::vector<std::string>) {"-a", "b"}));
     REQUIRE(!am.UseArg("duo"));

--- a/tests/test_config.cc
+++ b/tests/test_config.cc
@@ -83,12 +83,16 @@ TEST_CASE("Test config", "[config]"){
   {
 
     emp::vector<std::string> arguments = {
+      "-unspecified",
+      "unspec",
+      "unspec",
       "--dir",
       "/some_path",
       "-d",
       "/other_path",
       "pos1",
       "pos2",
+      "-unspecified",
       "-help",
       "pos3",
       "--duo",
@@ -137,13 +141,17 @@ TEST_CASE("Test config", "[config]"){
 
     REQUIRE(
       *am.UseArg("_positional")
-      == ((emp::vector<std::string>) {"pos1", "pos2", "pos3", "b", "pos4"})
+      == ((emp::vector<std::string>) {"pos1", "pos2", "pos3", "pos4"})
     );
     REQUIRE(!am.UseArg("_positional"));
 
     REQUIRE(
       am.ViewArg("_unknown")
-      == (emp::vector<emp::vector<std::string>>) {{"-a"}}
+      == ((emp::vector<emp::vector<std::string>>) {
+        {"-unspecified", "unspec", "unspec"},
+        {"-unspecified"},
+        {"-a", "b"}
+      })
     );
 
     REQUIRE(
@@ -175,6 +183,11 @@ TEST_CASE("Test config", "[config]"){
     emp::ArgManager am(argv.size() - 1, argv.data());
 
     REQUIRE(am.HasUnused());
+
+    REQUIRE(
+      am.ViewArg("_unknown")
+      == ((emp::vector<emp::vector<std::string>>) {{"--dir"}, {"/some_path"}})
+    );
 
   }
 

--- a/tests/test_config.cc
+++ b/tests/test_config.cc
@@ -64,11 +64,12 @@ TEST_CASE("Test config", "[config]"){
     argv.push_back(nullptr);
 
     auto specs = emp::ArgManager::make_builtin_specs();
-    specs.merge(
-      (std::unordered_map<std::string,emp::ArgSpec>)
-      { {"dir", emp::ArgSpec(1)} }
-    );
+    specs["dir"] = emp::ArgSpec(1);
 
+    // Alternatively, we could merge in additional specifications from another unordered map:
+    // std::unordered_map<std::string,emp::ArgSpec> additional_specs{"dir", emp::ArgSpec(1)};
+    // specs.merge(additional_specs);
+    
     emp::ArgManager am(
       argv.size() - 1,
       argv.data(),

--- a/tests/test_config.cc
+++ b/tests/test_config.cc
@@ -68,8 +68,6 @@ TEST_CASE("Test config", "[config]"){
       specs
     );
 
-    am.Print(std::cout);
-
     REQUIRE(am.HasUnused());
 
     REQUIRE(*am.UseArg("dir") == (emp::vector<std::string>) {"/some_path"} );
@@ -125,7 +123,7 @@ TEST_CASE("Test config", "[config]"){
       specs
     );
 
-    am.Print(std::cout);
+    am.PrintDiagnostic(std::cout);
 
     REQUIRE(am.HasUnused());
 
@@ -135,7 +133,6 @@ TEST_CASE("Test config", "[config]"){
 
     REQUIRE(!am.ProcessBuiltin());
     REQUIRE(!am.UseArg("help"));
-    REQUIRE(am.ProcessBuiltin(&config));
 
     REQUIRE(!am.UseArg("duo"));
 
@@ -145,14 +142,18 @@ TEST_CASE("Test config", "[config]"){
     );
     REQUIRE(!am.UseArg("_positional"));
 
+    REQUIRE(!am.ProcessBuiltin(&config));
     REQUIRE(
-      am.ViewArg("_unknown")
-      == ((emp::vector<emp::vector<std::string>>) {
-        {"-unspecified", "unspec", "unspec"},
-        {"-unspecified"},
-        {"-a", "b"}
-      })
+      *am.UseArg("_unknown")
+      == ((emp::vector<std::string>) {"-unspecified", "unspec", "unspec"})
     );
+    REQUIRE(
+      *am.UseArg("_unknown")
+      == (emp::vector<std::string>) {"-unspecified"}
+    );
+    REQUIRE(*am.UseArg("_unknown") == ((emp::vector<std::string>) {"-a", "b"}));
+    REQUIRE(!am.UseArg("_unknown"));
+    REQUIRE(am.ProcessBuiltin(&config));
 
     REQUIRE(
       am.ViewArg("duo")

--- a/tests/test_config.cc
+++ b/tests/test_config.cc
@@ -1,5 +1,5 @@
-// This file is part of Empirical, https://github.com/mercere99/Empirical/, and is  
-// Copyright (C) Michigan State University, 2015. It is licensed                
+// This file is part of Empirical, https://github.com/mercere99/Empirical/, and is
+// Copyright (C) Michigan State University, 2015. It is licensed
 // under the MIT Software license; see doc/LICENSE
 
 #define CATCH_CONFIG_MAIN

--- a/tests/test_config.cc
+++ b/tests/test_config.cc
@@ -7,6 +7,7 @@
 
 #include <iostream>
 #include <map>
+#include <optional>
 
 #include "base/assert.h"
 #include "base/vector.h"

--- a/tests/test_config.cc
+++ b/tests/test_config.cc
@@ -79,6 +79,7 @@ TEST_CASE("Test config", "[config]"){
 
   }
 
+  // more complicated test
   {
 
     emp::vector<std::string> arguments = {
@@ -91,6 +92,9 @@ TEST_CASE("Test config", "[config]"){
       "-help",
       "pos3",
       "--duo",
+      "b",
+      "--duo",
+      "-a",
       "b",
       "--duo",
       "a",
@@ -133,11 +137,45 @@ TEST_CASE("Test config", "[config]"){
 
     REQUIRE(
       *am.UseArg("_positional")
-      == ((emp::vector<std::string>) {"pos1", "pos2", "pos3", "pos4"})
+      == ((emp::vector<std::string>) {"pos1", "pos2", "pos3", "b", "pos4"})
     );
     REQUIRE(!am.UseArg("_positional"));
 
+    REQUIRE(
+      am.ViewArg("_unknown")
+      == (emp::vector<emp::vector<std::string>>) {{"-a"}}
+    );
+
+    REQUIRE(
+      am.ViewArg("duo")
+      == ((emp::vector<emp::vector<std::string>>) {{"b"},{},{"a","b"}})
+    );
+
+    REQUIRE(am.ViewArg("nope") == (emp::vector<emp::vector<std::string>>) {});
+    REQUIRE(
+      am.ViewArg("extra_nope")
+      == (emp::vector<emp::vector<std::string>>) {}
+    );
+    REQUIRE(!am.UseArg("nope"));
+    REQUIRE(!am.UseArg("extra_nope"));
+
     REQUIRE(am.HasUnused());
+  }
+
+  // when no spec is provided
+  {
+
+    emp::vector<std::string> arguments = {"--dir", "/some_path"};
+
+    std::vector<char*> argv;
+    for (const auto& arg : arguments) argv.push_back((char*)arg.data());
+
+    argv.push_back(nullptr);
+
+    emp::ArgManager am(argv.size() - 1, argv.data());
+
+    REQUIRE(am.HasUnused());
+
   }
 
 }

--- a/tests/test_config.cc
+++ b/tests/test_config.cc
@@ -17,6 +17,7 @@
 
 TEST_CASE("Test config", "[config]"){
 
+  // test config class template
   {
 
     MyConfig config;
@@ -234,7 +235,7 @@ TEST_CASE("Test config", "[config]"){
 
   }
 
-  // more complicated test
+  // test callbacks
   {
 
     MyConfig config;

--- a/tests/test_config.cc
+++ b/tests/test_config.cc
@@ -30,6 +30,7 @@ TEST_CASE("Test config", "[config]"){
 
   REQUIRE(config.RANDOM_SEED() == 123);
 
+  // old ArgManager in cl namespace
   {
 
     emp::vector<std::string> arguments = {"--dir", "/some_path"};
@@ -41,18 +42,7 @@ TEST_CASE("Test config", "[config]"){
 
     emp::cl::ArgManager am(argv.size() - 1, argv.data());
 
-  }
-
-  {
-
-    emp::vector<std::string> arguments = {"--dir", "/some_path"};
-
-    std::vector<char*> argv;
-    for (const auto& arg : arguments) argv.push_back((char*)arg.data());
-
-    argv.push_back(nullptr);
-
-    emp::ArgManager am(argv.size() - 1, argv.data());
+    REQUIRE(am.HasUnknown());
 
   }
 


### PR DESCRIPTION
The rewritten ArgManager lives in the `emp` namespace while the old ArgManager still lives in the `emp::cl` namespace. See `tests/test_config.cc` for examples of this in action.