### PR TITLE
Add third-party/emsdk/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,7 @@ tests/web/node_modules/
 tests/test_file.dat
 
 third-party/doxygen/
+third-party/emsdk/
 build/
 doc/_build/
 


### PR DESCRIPTION
third-party/doxygen/ was already in the .gitignore, emsdk also shouldn't be tracked