### PR TITLE
Add utils for SignalGP utils

### DIFF
--- a/source/base/vector.h
+++ b/source/base/vector.h
@@ -127,21 +127,21 @@ namespace emp {
         return wrapped_t::operator->();
       }
 
-      this_t & operator++() { 
+      this_t & operator++() {
         emp_assert(OK(true,false), ErrorCode());
         wrapped_t::operator++();
         return *this;
       }
-      this_t operator++(int x) { 
+      this_t operator++(int x) {
         emp_assert(OK(true,false), ErrorCode());
         return this_t(wrapped_t::operator++(x), v_ptr);
       }
-      this_t & operator--() { 
+      this_t & operator--() {
         emp_assert(OK(false,true), ErrorCode());
         wrapped_t::operator--();
         return *this;
       }
-      this_t operator--(int x) { 
+      this_t operator--(int x) {
         emp_assert(OK(false,true), ErrorCode());
         return this_t(wrapped_t::operator--(x), v_ptr);
       }

--- a/source/hardware/EventDrivenGP.h
+++ b/source/hardware/EventDrivenGP.h
@@ -731,7 +731,7 @@ namespace emp {
       template <class Archive>
       void serialize( Archive & ar )
       {
-          ar(program);
+        ar(program);
       }
 
     };

--- a/source/hardware/EventDrivenGP.h
+++ b/source/hardware/EventDrivenGP.h
@@ -310,11 +310,17 @@ namespace emp {
           return std::tie(id, args, affinity) < std::tie(other.id, other.args, other.affinity);
       }
 
+      #ifdef CEREAL_NVP
       template <class Archive>
       void serialize( Archive & ar )
       {
-        ar(affinity, args, id);
+        ar(
+          CEREAL_NVP(affinity),
+          CEREAL_NVP(args),
+          CEREAL_NVP(id)
+        );
       }
+      #endif
 
     };
 
@@ -409,11 +415,16 @@ namespace emp {
         inst_seq[pos].Set(inst);
       }
 
+      #ifdef CEREAL_NVP
       template <class Archive>
       void serialize( Archive & ar )
       {
-        ar(affinity, inst_seq);
+        ar(
+          CEREAL_NVP(affinity),
+          CEREAL_NVP(inst_seq)
+        );
       }
+      #endif
 
     };
 
@@ -728,11 +739,16 @@ namespace emp {
         }
       }
 
+
+      #ifdef CEREAL_NVP
       template <class Archive>
       void serialize( Archive & ar )
       {
-        ar(program);
+        ar(
+          CEREAL_NVP(program)
+        );
       }
+      #endif
 
     };
 

--- a/source/hardware/EventDrivenGP.h
+++ b/source/hardware/EventDrivenGP.h
@@ -310,6 +310,12 @@ namespace emp {
           return std::tie(id, args, affinity) < std::tie(other.id, other.args, other.affinity);
       }
 
+      template <class Archive>
+      void serialize( Archive & ar )
+      {
+        ar(affinity, args, id);
+      }
+
     };
 
     using inst_t = Instruction;                    //< Convenient Instruction type alias.
@@ -401,6 +407,12 @@ namespace emp {
 
       void SetInst(size_t pos, const inst_t & inst) {
         inst_seq[pos].Set(inst);
+      }
+
+      template <class Archive>
+      void serialize( Archive & ar )
+      {
+        ar(affinity, inst_seq);
       }
 
     };
@@ -714,6 +726,12 @@ namespace emp {
           }
           os << '\n';
         }
+      }
+
+      template <class Archive>
+      void serialize( Archive & ar )
+      {
+          ar(program);
       }
 
     };

--- a/source/hardware/InstLib.h
+++ b/source/hardware/InstLib.h
@@ -200,8 +200,9 @@ namespace emp {
 
     /// Print out summary of instruction library.
     void PrintManifest(std::ostream & os=std::cout) const {
+      os << "id" << "," << "name" << std::endl;
       for (size_t i = 0; i < inst_lib.size(); ++i) {
-        os << i << " " << inst_lib[i].name << std::endl;
+        os << i << "," << inst_lib[i].name << std::endl;
       }
     }
 

--- a/source/hardware/InstLib.h
+++ b/source/hardware/InstLib.h
@@ -198,6 +198,13 @@ namespace emp {
       }
     }
 
+    /// Print out summary of instruction library.
+    void PrintManifest(std::ostream & os=std::cout) const {
+      for (size_t i = 0; i < inst_lib.size(); ++i) {
+        os << i << " " << inst_lib[i].name << std::endl;
+      }
+    }
+
   };
 
 }

--- a/tests/test_hardware.cc
+++ b/tests/test_hardware.cc
@@ -4,6 +4,7 @@
 #include <unordered_set>
 
 #include <cereal/cereal.hpp>
+#include <cereal/types/array.hpp>
 #include <cereal/types/map.hpp>
 #include <cereal/types/vector.hpp>
 #include <cereal/types/string.hpp>

--- a/tests/test_hardware.cc
+++ b/tests/test_hardware.cc
@@ -3,6 +3,14 @@
 
 #include <unordered_set>
 
+#include <cereal/cereal.hpp>
+#include <cereal/types/map.hpp>
+#include <cereal/types/vector.hpp>
+#include <cereal/types/string.hpp>
+
+#include <cereal/archives/json.hpp>
+#include <cereal/archives/binary.hpp>
+
 #include "base/Ptr.h"
 #include "hardware/EventDrivenGP.h"
 #include "hardware/signalgp_utils.h"
@@ -378,6 +386,8 @@ TEST_CASE("Test SignalGP ('EventDrivenGP.h') utility: GenRandSignalGPInst", "[ha
   inst_lib.AddInst("SetMem", hardware_t::Inst_SetMem, 2, "Local memory: Arg1 = numerical value of Arg2");
   inst_lib.AddInst("Fork", hardware_t::Inst_Fork, 0, "Fork a new thread. Local memory contents of callee are loaded into forked thread's input memory.");
 
+  inst_lib.PrintManifest();
+
   // Generate a bunch of random instructions, check that they conform with requested bounds.
   for (size_t i = 0; i < 10000; ++i) {
     inst_t inst(emp::GenRandSignalGPInst(random, inst_lib, MIN_ARG_VAL, MAX_ARG_VAL));
@@ -510,6 +520,48 @@ TEST_CASE("Test SignalGP ('EventDrivenGP.h') utility: GenRandSignalGPProgram", "
     hw.Reset();
     hw.SetProgram(program);
     hw.Process(128);
+
+    { // test with JSON archive
+    std::stringstream stringstream;
+
+    {
+      cereal::JSONOutputArchive json_out(stringstream);
+      json_out(program);
+    }
+
+    cereal::JSONInputArchive json_in(stringstream);
+
+    program_t json_program(&inst_lib);
+    json_in(json_program);
+
+    REQUIRE(json_program == program);
+
+    hw.Reset();
+    hw.SetProgram(json_program);
+    hw.Process(128);
+    }
+
+    { // test with binary archive
+    std::stringstream stringstream;
+
+    {
+      cereal::BinaryOutputArchive binary_out(stringstream);
+      binary_out(program);
+    }
+
+    cereal::BinaryInputArchive binary_in(stringstream);
+
+    program_t binary_program(&inst_lib);
+    binary_in(binary_program);
+
+    REQUIRE(binary_program == program);
+
+    hw.Reset();
+    hw.SetProgram(binary_program);
+    hw.Process(128);
+    }
+
+
   }
 }
 


### PR DESCRIPTION
@NateRiz had implemented Cereal based program serialization/deserialization but it got lost in the shuffle. Also added a helper function to print an itinerary of an instruction library.