### PR TITLE
Fix overzealous assert in Entropy calculation

### DIFF
--- a/source/tools/info_theory.h
+++ b/source/tools/info_theory.h
@@ -46,7 +46,10 @@ namespace emp {
   double Entropy(const CONTAINER & objs, WEIGHT_FUN fun, double total=0.0) {
     // If we don't know the total, calculate it.
     if (total == 0.0) for (auto & o : objs) total += (double) fun(o);
-    emp_assert(total > 0.0);
+
+    // we *can* calculate the entropy of the empty set
+    // https://www.askamathematician.com/2011/02/q-what-is-the-entropy-of-nothing/
+    emp_assert(total > 0.0 || std::size(objs) == 0);
 
     double entropy = 0.0;
     for (auto & o : objs) {


### PR DESCRIPTION
We *can* calculate the entropy of an empty set.