### PR TITLE
Add cryptographic hash metric

### DIFF
--- a/source/Evolve/World.h
+++ b/source/Evolve/World.h
@@ -261,7 +261,13 @@ namespace emp {
 
     /// Get the organism most frequently found in the population and its
     /// abundance.
+    /// Be sure to check whether the population is empty before calling!
     std::pair<org_t, size_t> GetDominantInfo() const {
+
+      emp_assert(
+        GetNumOrgs(),
+        "called GetDominantInfo on an empty population"
+      );
 
       std::map<org_t, size_t> counts;
       for (const auto & org_ptr : GetFullPop()) {
@@ -279,6 +285,7 @@ namespace emp {
     }
 
     /// Get the organism most frequently found in the population.
+    /// Be sure to check whether the population is empty before calling!
     org_t GetDominantOrg() const { return GetDominantInfo().first; }
 
     /// What phenotypic traits is the population tracking?

--- a/source/tools/BitSet.h
+++ b/source/tools/BitSet.h
@@ -526,6 +526,9 @@ namespace emp {
     /// How many bits are in this BitSet?
     constexpr static size_t GetSize() { return NUM_BITS; }
 
+    /// How many bytes are in this BitSet?
+    constexpr static size_t GetNumBytes() { return NUM_BYTES; }
+
     /// Retrieve the bit as a specified index.
     bool Get(size_t index) const {
       emp_assert(index >= 0 && index < NUM_BITS);

--- a/source/tools/matchbin_metrics.h
+++ b/source/tools/matchbin_metrics.h
@@ -129,7 +129,7 @@ namespace emp {
     // adapted from https://www.uncg.edu/cmp/faculty/srtate/580.f11/sha1examples.php
     double operator()(const query_t& a, const tag_t& b) const override {
 
-    std::array<unsigned char, query_t::GetNumBytes()+tag_t::GetNumBytes()> data;
+    std::array<unsigned char, a.GetNumBytes() + b.GetNumBytes()> data;
 
     size_t i = 0;
     for (size_t j = 0; j < a.GetNumBytes(); ++j) data[i++] = a.GetByte(j);

--- a/source/tools/matchbin_metrics.h
+++ b/source/tools/matchbin_metrics.h
@@ -26,6 +26,8 @@
 #include <utility>
 #include <queue>
 
+#include <openssl/sha.h>
+
 #include "tools/Binomial.h"
 
 #include "../base/assert.h"
@@ -103,6 +105,53 @@ namespace emp {
         thasher(b)
       )) / std::numeric_limits<size_t>::max();
     }
+
+  };
+
+  /// Generate an arbitrary, but consistent, match score between 0 and 1
+  template<size_t Width>
+  struct CryptoHashMetric: public BaseMetric<emp::BitSet<Width>, emp::BitSet<Width>> {
+
+    using query_t = emp::BitSet<Width>;
+    using tag_t = emp::BitSet<Width>;
+
+    size_t dim() const override { return 1; }
+
+    size_t width() const override { return Width; }
+
+    std::string name() const override {
+      return emp::to_string(Width) + "-bit " + base();
+    }
+
+    std::string base() const override { return "Hash Metric"; }
+
+    // adapted from https://www.uncg.edu/cmp/faculty/srtate/580.f11/sha1examples.php
+    double operator()(const query_t& a, const tag_t& b) const override {
+
+    std::array<unsigned char, query_t::GetNumBytes()+tag_t::GetNumBytes()> data;
+
+    size_t i = 0;
+    for (size_t j = 0; j < a.GetNumBytes(); ++j) data[i++] = a.GetByte(j);
+    for (size_t j = 0; j < b.GetNumBytes(); ++j) data[i++] = b.GetByte(j);
+
+    SHA_CTX shactx;
+    std::array<unsigned char, SHA_DIGEST_LENGTH> digest;
+
+    SHA1_Init(&shactx);
+    SHA1_Update(&shactx, data.data(), data.size());
+    SHA1_Final(digest.data(), &shactx);
+
+    const std::string hashme{
+      reinterpret_cast<const char *>(digest.data()),
+      digest.size()
+    };
+
+    return (
+      static_cast<double>(std::hash<std::string>{}(hashme))
+      / std::numeric_limits<size_t>::max()
+    );
+
+  }
 
   };
 

--- a/source/tools/matchbin_metrics.h
+++ b/source/tools/matchbin_metrics.h
@@ -109,6 +109,7 @@ namespace emp {
   };
 
   /// Generate an arbitrary, but consistent, match score between 0 and 1
+  /// Be sure to link against -lcrypto and -lssl
   template<size_t Width>
   struct CryptoHashMetric: public BaseMetric<emp::BitSet<Width>, emp::BitSet<Width>> {
 

--- a/tests/test_tools.cc
+++ b/tests/test_tools.cc
@@ -410,6 +410,27 @@ template class emp::BitSet<5>;
 TEST_CASE("Test BitSet", "[tools]")
 {
 
+  // test BitSet GetSize, GetNumBytes
+  {
+    REQUIRE(emp::BitSet<2>{}.GetSize() == 2);
+    REQUIRE(emp::BitSet<2>{}.GetNumBytes() == 1);
+
+    REQUIRE(emp::BitSet<7>{}.GetSize() == 7);
+    REQUIRE(emp::BitSet<7>{}.GetNumBytes() == 1);
+
+    REQUIRE(emp::BitSet<8>{}.GetSize() == 8);
+    REQUIRE(emp::BitSet<8>{}.GetNumBytes() == 1);
+
+    REQUIRE(emp::BitSet<9>{}.GetSize() == 9);
+    REQUIRE(emp::BitSet<9>{}.GetNumBytes() == 2);
+
+    REQUIRE(emp::BitSet<16>{}.GetSize() == 16);
+    REQUIRE(emp::BitSet<16>{}.GetNumBytes() == 2);
+
+    REQUIRE(emp::BitSet<24>{}.GetSize() == 24);
+    REQUIRE(emp::BitSet<24>{}.GetNumBytes() == 3);
+  }
+
   // test BitSet reverse
   {
 


### PR DESCRIPTION
@amlalejini and I ran into some weird artifacts using `hash_combine` as a metric (e.g., we found subsets of all possible tags A and B such that the hash(A,B) results weren't uniformly distributed between 0 and 1. I ran some preliminary experiments and it looks like using a SHA cryptographic hash fixes the artifacts.

I use the openssl/libcrypto SHA tools in the implementation. This requires linking with -lcrypto -lssl to **use** the metric, but everything compiles fine without linking when the metric isn't actually instantiated/used.  I documented the linking requirement to use `CryptoHashMetric` in a docstring associated with it.

I wrote tests for a `GetNumBytes` function I slapped on to `BitSet` but I didn't write tests for the `CryptoHashMetric` so that we don't have to worry about any new linkage requirements in our test suite.