### PR TITLE
fix for #247

### DIFF
--- a/source/base/array.h
+++ b/source/base/array.h
@@ -197,7 +197,7 @@ namespace emp {
 
 // specialization for std::tuple_size
 template <class T, size_t N>
-class std::tuple_size<emp::array<T, N>> : public integral_constant<size_t, N> {
+struct std::tuple_size<emp::array<T, N>> : public integral_constant<size_t, N> {
 };
 
 // A crude, generic printing function for arrays.

--- a/source/base/array.h
+++ b/source/base/array.h
@@ -195,6 +195,11 @@ namespace emp {
 
 }
 
+// specialization for std::tuple_size
+template <class T, size_t N>
+class std::tuple_size<emp::array<T, N>> : public integral_constant<size_t, N> {
+};
+
 // A crude, generic printing function for arrays.
 template <typename T, size_t N>
 std::ostream & operator<<(std::ostream & out, const emp::array<T,N> & v) {

--- a/tests/test_base.cc
+++ b/tests/test_base.cc
@@ -36,7 +36,7 @@ TEST_CASE("Test array", "[base]")
   constexpr int A_SIZE = 50;
   emp::array<int, A_SIZE> test_array;
   
-  REQUIRE(std::tuple_size<test_array>::value == A_SIZE);
+  REQUIRE(std::tuple_size<decltype(test_array)>::value == A_SIZE);
 
   for (size_t i = 0; i < A_SIZE; i++) {
     test_array[i] = (int) (i * i);

--- a/tests/test_base.cc
+++ b/tests/test_base.cc
@@ -35,6 +35,8 @@ TEST_CASE("Test array", "[base]")
 {
   constexpr int A_SIZE = 50;
   emp::array<int, A_SIZE> test_array;
+  
+  REQUIRE(std::tuple_size<test_array>::value == A_SIZE);
 
   for (size_t i = 0; i < A_SIZE; i++) {
     test_array[i] = (int) (i * i);


### PR DESCRIPTION
This should be correct (it's basically copied from the specialization for std::array). 
The specialization is for a class type, it depends on a program-defined type (emp::array in this case), and the specialization satisfies the UnaryTypeTrait concept (inherited from std::integral_constant).