### PR TITLE
Track breaking string_utils API change

### DIFF
--- a/source/tools/keyname_utils.h
+++ b/source/tools/keyname_utils.h
@@ -79,9 +79,9 @@ namespace emp::keyname {
 
     const auto kv_strs = emp::slice(
 #ifndef __EMSCRIPTEN__
-      std::filesystem::path(filename).filename(), // get basename
+      std::filesystem::path(filename).filename().string(), // get basename
 #else
-      std::experimental::filesystem::path(filename).filename(), // get basename
+      std::experimental::filesystem::path(filename).filename().string(), // get basename
 #endif
       '+'
     );


### PR DESCRIPTION
issue was caused because some things that implicitly converted to string don’t implicitly convert to string_view