### PR TITLE
Make SpatialCoop2017 app work with current version

### DIFF
--- a/apps/SpatialCoop2017/source/web/SimplePDWorld-web.cc
+++ b/apps/SpatialCoop2017/source/web/SimplePDWorld-web.cc
@@ -77,7 +77,7 @@ int anim_step = 1;
 
 void TogglePlay()
 {
-  auto & anim = doc.AddAnimation("anim_world");
+  auto & anim = doc.Animate("anim_world");
   anim.ToggleActive();
   auto but = doc.Button("start_but");
   if (anim.GetActive()) but.SetLabel("Pause");


### PR DESCRIPTION
Currently, the SpatialCoop2017 app doesn't do anything if you click play on the web version. This is just a minor fix to make it work again with the current version of Empirical.