### PR TITLE
Handle key case better in KeypressManager

### DIFF
--- a/source/base/errors.h
+++ b/source/base/errors.h
@@ -124,7 +124,7 @@ namespace emp {
     }
   }
 
-  /// Send information to a program user (via standard error in native mode, or alter in Emscripten)
+  /// Send information to a program user (via standard error in native mode, or alert in Emscripten)
   template <typename... Ts>
   void Notify(Ts &&... args) {
     std::stringstream ss;

--- a/source/web/KeypressManager.h
+++ b/source/web/KeypressManager.h
@@ -97,8 +97,10 @@ namespace web {
     ///  The function must take in an emp::web::KeyboardEvent (which includes information about
     ///  the specific key pressed as well as any modifiers such as SHIFT or CTRL) and it
     ///  must return a boolean value indicating whether it has resolved the keypress.
-    void AddKeydownCallback(std::function<bool(const KeyboardEvent &)> cb_fun, int order=-1)
-    {
+    void AddKeydownCallback(
+      std::function<bool(const KeyboardEvent &)> cb_fun,
+      int order=-1
+    ) {
       if (order == -1) order = next_order;
       if (order >= next_order) next_order = order+1;
 
@@ -107,8 +109,11 @@ namespace web {
 
     ///  Link a specific key to a target function to be called when that key is pressed.
     ///  The function my return a void and take no arguments.
-    void AddKeydownCallback(char key, std::function<void()> cb_fun, int order=-1)
-    {
+    void AddKeydownCallback(
+      char key,
+      std::function<void()> cb_fun,
+      int order=-1
+    ) {
       if (order == -1) order = next_order;
       if (order >= next_order) next_order = order+1;
 
@@ -119,19 +124,27 @@ namespace web {
 
     /// Provide a whole set of keys that should all trigger the same function, including an
     /// ordering for priority.
-    void AddKeydownCallback(const std::string & key_set, const std::function<void()> & cb_fun,
-                            int order)
-    {
+    void AddKeydownCallback(
+      const std::string & key_set,
+      const std::function<void()> & cb_fun,
+      int order
+    ) {
       if (order >= next_order) next_order = order+1;
 
-      fun_map[order] =
-        [key_set, cb_fun](const KeyboardEvent & evt)
-        { if (key_set.find((char)evt.keyCode) == std::string::npos) return false; cb_fun(); return true;};
+      fun_map[order] = [key_set, cb_fun](const KeyboardEvent & evt) {
+        if (key_set.find((char)evt.keyCode) == std::string::npos) {
+          return false;
+        }
+        cb_fun();
+        return true;
+      };
     }
 
     /// Provide a whole set of keys that should all trigger the same function; use default ordering.
-    void AddKeydownCallback(const std::string & key_set, const std::function<void()> & cb_fun)
-    {
+    void AddKeydownCallback(
+      const std::string & key_set,
+      const std::function<void()> & cb_fun
+    ) {
       AddKeydownCallback(key_set, cb_fun, next_order);
     }
   };

--- a/source/web/KeypressManager.h
+++ b/source/web/KeypressManager.h
@@ -122,7 +122,7 @@ namespace web {
       if (order == -1) order = next_order;
       if (order >= next_order) next_order = order+1;
 
-      if (std::isupper(key)) emp::NotifyWarning(
+      if (std::isupper(key)) emp::LibraryWarning(
         "Uppercase character was passed for the key argument. ",
         "To specify uppercase, you'll need to monitor for the shift modifier associated with a KeypressEvent."
       );

--- a/source/web/KeypressManager.h
+++ b/source/web/KeypressManager.h
@@ -112,6 +112,8 @@ namespace web {
 
     ///  Link a specific key to a target function to be called when that key is pressed.
     ///  The function my return a void and take no arguments.
+    /// Specify keys as lowercase characters. To sepcify uppercase, you'll
+    /// need to monitor fo rthe shift modifier associated with a KeypressEvent.
     void AddKeydownCallback(
       char key,
       std::function<void()> cb_fun,
@@ -134,6 +136,8 @@ namespace web {
 
     /// Provide a whole set of keys that should all trigger the same function, including an
     /// ordering for priority.
+    /// Specify keys as lowercase characters. To sepcify uppercase, you'll
+    /// need to monitor fo rthe shift modifier associated with a KeypressEvent.
     void AddKeydownCallback(
       const std::string & key_set,
       const std::function<void()> & cb_fun,

--- a/source/web/KeypressManager.h
+++ b/source/web/KeypressManager.h
@@ -15,11 +15,11 @@
  *
  *  The specific versions of AddKeydownCallback are:
  *
- *    void AddKeydownCallback(std::function<bool(const html5::KeyboardEvent &)> cb_fun,
+ *    void AddKeydownCallback(std::function<bool(const emp::web::KeyboardEvent &)> cb_fun,
  *                            int order=-1)
  *
  *      Link a function to the KeypressManager that is called for any unresolved keypress.
- *      The function must take in an html5::KeyboardEvent (which includes information about
+ *      The function must take in an emp::web::KeyboardEvent (which includes information about
  *      the specific key pressed as well as any modifiers such as SHIFT or CTRL) and it
  *      must return a boolean value indicating whether it has resolved the keypress.
  *
@@ -94,7 +94,7 @@ namespace web {
     int GetNextOrder() const { return next_order; }
 
     ///  Link a function to the KeypressManager that is called for any unresolved keypress.
-    ///  The function must take in an html5::KeyboardEvent (which includes information about
+    ///  The function must take in an emp::web::KeyboardEvent (which includes information about
     ///  the specific key pressed as well as any modifiers such as SHIFT or CTRL) and it
     ///  must return a boolean value indicating whether it has resolved the keypress.
     void AddKeydownCallback(std::function<bool(const KeyboardEvent &)> cb_fun, int order=-1)

--- a/source/web/KeypressManager.h
+++ b/source/web/KeypressManager.h
@@ -47,6 +47,8 @@
 #include <map>
 #include <locale>
 
+#include "../base/errors.h"
+
 #include "events.h"
 #include "JSWrap.h"
 
@@ -118,6 +120,11 @@ namespace web {
       if (order == -1) order = next_order;
       if (order >= next_order) next_order = order+1;
 
+      if (std::isupper(key)) emp::NotifyWarning(
+        "Uppercase character was passed for the key argument. ",
+        "To specify uppercase, you'll need to monitor for the shift modifier associated with a KeypressEvent."
+      );
+
       key = std::toupper(key);
 
       fun_map[order] =
@@ -133,6 +140,15 @@ namespace web {
       int order
     ) {
       if (order >= next_order) next_order = order+1;
+
+      if (std::any_of(
+        std::begin(key_set),
+        std::end(key_set),
+        ::isupper
+      )) emp::NotifyWarning(
+        "Uppercase character was passed for the key argument. ",
+        "To specify uppercase, you'll need to monitor for the shift modifier associated with a KeypressEvent."
+      );
 
       std::string uppercase_key_set{key_set};
       std::transform(

--- a/source/web/KeypressManager.h
+++ b/source/web/KeypressManager.h
@@ -45,6 +45,7 @@
 
 #include <functional>
 #include <map>
+#include <locale>
 
 #include "events.h"
 #include "JSWrap.h"
@@ -117,6 +118,8 @@ namespace web {
       if (order == -1) order = next_order;
       if (order >= next_order) next_order = order+1;
 
+      key = std::toupper(key);
+
       fun_map[order] =
         [key, cb_fun](const KeyboardEvent & evt)
         { if (evt.keyCode == key) { cb_fun(); return true; } return false; };
@@ -130,6 +133,14 @@ namespace web {
       int order
     ) {
       if (order >= next_order) next_order = order+1;
+
+      std::string uppercase_key_set{key_set};
+      std::transform(
+        std::begin(uppercase_key_set),
+        std::end(uppercase_key_set),
+        std::begin(uppercase_key_set),
+        ::toupper
+      );
 
       fun_map[order] = [key_set, cb_fun](const KeyboardEvent & evt) {
         if (key_set.find((char)evt.keyCode) == std::string::npos) {


### PR DESCRIPTION
If a user specifies lowercase character arguments, handle them correctly.
If a user specifies uppercase character arguments, warn them that they need to monitor for shift separately and proceed as usual.
Update docstrings.