### PR TITLE
Add KeyboardEvent overload for Widget.On()

### DIFF
--- a/source/web/Widget.h
+++ b/source/web/Widget.h
@@ -661,6 +661,16 @@ namespace web {
         DoListen(event_name, fun_id);
         return (return_t &) *this;
       }
+      
+      /// Provide an event and a function that will be called when that event is triggered.
+      /// In this case, the function takes a keyboard event as an argument, with full info about keyboard.
+      return_t & On(const std::string & event_name,
+                    const std::function<void(KeyboardEvent evt)> & fun) {
+        emp_assert(info != nullptr);
+        size_t fun_id = JSWrap(fun);
+        DoListen(event_name, fun_id);
+        return (return_t &) *this;
+      }
 
       /// Provide an event and a function that will be called when that event is triggered.
       /// In this case, the function takes two doubles which will be filled in with mouse coordinates.


### PR DESCRIPTION
Adds an overload for the Widget.On() method, so that a user can pass the method a function that takes a KeyboardEvent as an argument.