### PR TITLE
Updates to Axis

### DIFF
--- a/source/web/d3/axis.h
+++ b/source/web/d3/axis.h
@@ -375,11 +375,18 @@ namespace D3 {
 
   /// Helper function to draw a standard set of x and y axes at bottom and left.
   /// Takes the desired x axis, y axis, and the selection on which to draw them.
+  ///
   /// Only takes padding into account (not shift). If either axis specifies
   /// a padding value, it will be moved that distance away from the svg border and
   /// the axes will meet at their origins. By default, they will have 60px padding.
+  ///
+  /// The axes' scale ranges' lower limits must be zero for the axes' origins to match up.
+  /// To move the pair to a different place, add padding values when constructing each axis.
+  /// The padding on the bottom axis will be their distance from the bottom of the svg,
+  /// and the padding on the left axis will be their distance from the svg's left edge.
   template <typename SCALE_X_TYPE = D3::LinearScale, typename SCALE_Y_TYPE = D3::LinearScale>
   void DrawAxes(Axis<SCALE_X_TYPE> & x_axis, Axis<SCALE_Y_TYPE> & y_axis, Selection & selection){
+
     double x_axis_padding;
     double y_axis_padding;
 
@@ -405,9 +412,13 @@ namespace D3 {
       const x_axis_padding = $4;
       const y_axis_padding = $5;
 
-      var y_axis_height = d3.max(emp_d3.objects[y_axis].scale().range());
       var svg_width = emp_d3.objects[svg].attr("width");
       var svg_height = emp_d3.objects[svg].attr("height");
+
+      var y_axis_range_low = d3.min(emp_d3.objects[y_axis].scale().range());
+      var y_axis_range_high = d3.max(emp_d3.objects[y_axis].scale().range());
+
+      var y_axis_height = y_axis_range_high - y_axis_range_low;
 
       emp_d3.objects[x_axis_g].attr("transform", "translate("+y_axis_padding+","+(svg_height - x_axis_padding)+")");
       emp_d3.objects[y_axis_g].attr("transform", "translate("+y_axis_padding+","+(svg_height - y_axis_height - x_axis_padding)+")");

--- a/source/web/d3/axis.h
+++ b/source/web/d3/axis.h
@@ -148,24 +148,26 @@ namespace D3 {
         const shift_x = $9;
         const shift_y = $10;
 
-        var axis_range = emp_d3.objects[id].scale().range();
         emp_d3.objects[g] = emp_d3.objects[sel].append("g");
         emp_d3.objects[g].append("g")
-                    .attr("id", dom_id)
-                    .call(emp_d3.objects[id]);
+                         .attr("id", dom_id)
+                         .call(emp_d3.objects[id]);
 
         var svg_width = emp_d3.objects[sel].attr("width");
         var svg_height = emp_d3.objects[sel].attr("height");
 
+        var axis_range_low = d3.min(emp_d3.objects[id].scale().range());
+        var axis_range_high = d3.max(emp_d3.objects[id].scale().range());
+
         var dy = "0em";
-        var x_divisor = 2;
         var text_orient = 0;
         var padding_translation = "";
         if (orient == "top") {
           dy = "-2.5em";
           padding_translation = "translate(0,"+padding+")";
         } else if (orient == "left") {
-          x_divisor = -2;
+          axis_range_low *= -1;  // since left axis label is rotated -90,
+          axis_range_high *= -1; // range values must be given opposite sign
           dy = "-2.5em";
           text_orient = -90;
           padding_translation = "translate("+padding+",0)";
@@ -188,9 +190,7 @@ namespace D3 {
           dy = label_offset;
         }
 
-        var label_x = (axis_range[0] < axis_range[1])
-                    ? axis_range[0] + (axis_range[1]-axis_range[0])/x_divisor
-                    : axis_range[1] + (axis_range[0]-axis_range[1])/x_divisor;
+        var label_x = axis_range_low + (axis_range_high - axis_range_low) / 2;
 
         emp_d3.objects[g].append("text")
                      .attr("id", dom_id+"_label")

--- a/source/web/d3/axis.h
+++ b/source/web/d3/axis.h
@@ -85,9 +85,10 @@ namespace D3 {
       }, this->id, scale.GetID(), type.c_str());
     }
 
-    /// Consruct an axis and specify its initial position in px with shift_x and shift_y.
+    /// Construct an axis and specify its initial position in px with shift_x and shift_y.
     /// For example, given a shift_x of 50 and shift_y of 100, the axis will be shifted
-    /// 50px to the right and 100px down from its origin.
+    /// 50px to the right and 100px down from its origin. It's very helpful to use this
+    /// constructor to position your axes if you're using a scale range minimum that isn't zero.
     ///
     /// This doesn't draw anything yet, but sets up the necessary infrastructure
     /// to draw it when you call the Draw method. Optionally takes a label to label the axis with.
@@ -132,7 +133,6 @@ namespace D3 {
       std::string nospace_label = label;
       emp::remove_whitespace(nospace_label); // DOM ids can't contain whitespace
       dom_id = (label != "") ? nospace_label + "_axis"
-             //: emp::to_string(scale.GetID()) + "_axis";
              : "axis_" + emp::to_string(this->id);
 
       EM_ASM({
@@ -376,14 +376,13 @@ namespace D3 {
   /// Helper function to draw a standard set of x and y axes at bottom and left.
   /// Takes the desired x axis, y axis, and the selection on which to draw them.
   ///
-  /// Only takes padding into account (not shift). If either axis specifies
-  /// a padding value, it will be moved that distance away from the svg border and
-  /// the axes will meet at their origins. By default, they will have 60px padding.
+  /// Only takes padding into account (not shift). The padding on the bottom axis
+  /// will be their distance from the bottom of the svg, and the padding on the left axis
+  /// will be their distance from the svg's left edge. The axes will meet at their origins.
+  /// By default, they will have 60px padding.
   ///
   /// The axes' scale ranges' lower limits must be zero for the axes' origins to match up.
-  /// To move the pair to a different place, add padding values when constructing each axis.
-  /// The padding on the bottom axis will be their distance from the bottom of the svg,
-  /// and the padding on the left axis will be their distance from the svg's left edge.
+  /// TODO: make this function work with non-zero scale range minimums
   template <typename SCALE_X_TYPE = D3::LinearScale, typename SCALE_Y_TYPE = D3::LinearScale>
   void DrawAxes(Axis<SCALE_X_TYPE> & x_axis, Axis<SCALE_Y_TYPE> & y_axis, Selection & selection){
 

--- a/source/web/d3/axis.h
+++ b/source/web/d3/axis.h
@@ -323,8 +323,8 @@ namespace D3 {
       emp_assert((dom_id != "") && "WARNING: Calling Draw() after this method will overwrite your changes");
 
       EM_ASM({
-	      emp_d3.objects[$0].ticks($1, $2);
-	    }, this->id, count, format);
+	      emp_d3.objects[$0].ticks($1, d3.format(UTF8ToString($2)));
+	    }, this->id, count, format.c_str());
       return *this;
     }
 

--- a/tests/web/d3/axis.cc
+++ b/tests/web/d3/axis.cc
@@ -158,12 +158,8 @@ struct Test_Axis : emp::web::BaseTest {
     // set the svg for shifted axes testing to 600x600px (taller to fit vertical axis)
     svg_drawn_axes = D3::Select("#drawn_axes_div").Append("svg").SetAttr("id", "drawn_axes_svg").SetAttr("width", 600).SetAttr("height", 600);
     // set up axes to test DrawAxes() function
-
-    D3::LinearScale new_scale = D3::LinearScale();
-    new_scale.SetDomain(0, 100).SetRange(200, 400);
-
-    drawn_bottom_axis = D3::Axis<D3::LinearScale>("bottom", "DrawAxes Bottom", 90).SetScale(new_scale);
-    drawn_left_axis = D3::Axis<D3::LinearScale>  ("left", "DrawAxes Left", 170).SetScale(new_scale);
+    drawn_bottom_axis = D3::Axis<D3::LinearScale>("bottom", "DrawAxes Bottom", 90).SetScale(scale);
+    drawn_left_axis = D3::Axis<D3::LinearScale>  ("left", "DrawAxes Left", 170).SetScale(scale);
     DrawAxes(drawn_bottom_axis, drawn_left_axis, svg_drawn_axes);
 
     //////////////////////////////////////
@@ -347,7 +343,7 @@ struct Test_Axis : emp::web::BaseTest {
 
       describe("Padded axisBottom", function() {
 
-        var pad_b_axis_container = d3.select("#padded_axes_svg>g:nth-child(1)");
+        var pad_b_axis_container = d3.select("#padded_axes_svg>g:nth-child(1)"); // padding: 0
         var pad_b_axis = d3.select("#padded_axes_svg>g:nth-child(1)>g");
 
         it("should set id to 'axis_<cpp_id>' since no label provided", function() {
@@ -363,7 +359,7 @@ struct Test_Axis : emp::web::BaseTest {
 
       describe("Padded axisTop", function() {
 
-        var pad_t_axis_container = d3.select("#padded_axes_svg>g:nth-child(2)");
+        var pad_t_axis_container = d3.select("#padded_axes_svg>g:nth-child(2)"); // padding: 80
         var pad_t_axis = d3.select("#padded_axes_svg>g:nth-child(2)>g");
         var pad_t_axis_label = d3.select("#padded_axes_svg>g:nth-child(2)>text");
 
@@ -379,7 +375,7 @@ struct Test_Axis : emp::web::BaseTest {
 
       describe("Padded axisLeft", function() {
 
-        var pad_l_axis_container = d3.select("#padded_axes_svg>g:nth-child(3)");
+        var pad_l_axis_container = d3.select("#padded_axes_svg>g:nth-child(3)"); // padding: 70
         var pad_l_axis = d3.select("#padded_axes_svg>g:nth-child(3)>g");
         var pad_l_axis_label = d3.select("#padded_axes_svg>g:nth-child(3)>text");
 
@@ -395,7 +391,7 @@ struct Test_Axis : emp::web::BaseTest {
 
       describe("Padded axisRight", function() {
 
-        var pad_r_axis_container = d3.select("#padded_axes_svg>g:nth-child(4)");
+        var pad_r_axis_container = d3.select("#padded_axes_svg>g:nth-child(4)"); // padding: -10
         var pad_r_axis = d3.select("#padded_axes_svg>g:nth-child(4)>g");
         var pad_r_axis_label = d3.select("#padded_axes_svg>g:nth-child(4)>text");
 
@@ -415,10 +411,10 @@ struct Test_Axis : emp::web::BaseTest {
     EM_ASM({
       describe("Shifted Axis", function() {
 
-        var shift_axis_container = d3.select("#shifted_axes_svg>g:nth-child(1)");
+        var shift_axis_container = d3.select("#shifted_axes_svg>g:nth-child(1)"); // shift: 0,75
         var shift_axis = d3.select("#shifted_axes_svg>g:nth-child(1)>g");
 
-        var labeled_shift_axis_container = d3.select("#shifted_axes_svg>g:nth-child(2)");
+        var labeled_shift_axis_container = d3.select("#shifted_axes_svg>g:nth-child(2)"); // shift: 30,55
         var labeled_shift_axis = d3.select("#shifted_axes_svg>g:nth-child(2)>g");
         var labeled_shift_axis_label = d3.select("#shifted_axes_svg>g:nth-child(2)>text");
 
@@ -587,11 +583,11 @@ struct Test_Axis : emp::web::BaseTest {
 
       describe("Different Ranges row2col1", function() {
 
-        var ranges_row2col1_bottom_container = d3.select("#different_ranges_svg>g:nth-child(5)");
+        var ranges_row2col1_bottom_container = d3.select("#different_ranges_svg>g:nth-child(5)"); // shifted -20
         var ranges_row2col1_bottom_axis = d3.select("#different_ranges_svg>g:nth-child(5)>g");
         var ranges_row2col1_bottom_axis_label = d3.select("#different_ranges_svg>g:nth-child(5)>text");
 
-        var ranges_row2col1_left_container = d3.select("#different_ranges_svg>g:nth-child(6)");
+        var ranges_row2col1_left_container = d3.select("#different_ranges_svg>g:nth-child(6)"); // shifted -20
         var ranges_row2col1_left_axis = d3.select("#different_ranges_svg>g:nth-child(6)>g");
         var ranges_row2col1_left_axis_label = d3.select("#different_ranges_svg>g:nth-child(6)>text");
 
@@ -669,7 +665,7 @@ emp::web::MochaTestRunner test_runner;
 
 int main() {
   test_runner.Initialize({"emp_test_container"});
-  D3::internal::get_emp_d3();
+  D3::InitializeEmpD3();
 
   test_runner.AddTest<Test_Axis>("Axis");
 

--- a/tests/web/d3/axis.cc
+++ b/tests/web/d3/axis.cc
@@ -92,7 +92,7 @@ struct Test_Axis : emp::web::BaseTest {
 
     // set up a simple scale that all of the axes will be constructed on
     scale = D3::LinearScale();
-    scale.SetDomain(0, 100).SetRange(0, 500);
+    scale.SetDomain(0, 100).SetRange(50, 500);
 
     // set up axis for testing the default axis constructor
     default_axis = D3::Axis<D3::LinearScale>().SetScale(scale).Draw(svg_default_axis);

--- a/tests/web/d3/axis.cc
+++ b/tests/web/d3/axis.cc
@@ -31,6 +31,8 @@
 //     - rescale axis by new domain
 //     - adjust label offset correctly
 //     - set tick size, padding, number, format, and new values
+//   - DrawAxes() convenience function (bottom and left axes that meet at origin)
+//     - position the axes correctly (both padding values taken into account)
 
 struct Test_Axis : emp::web::BaseTest {
 
@@ -40,6 +42,7 @@ struct Test_Axis : emp::web::BaseTest {
   D3::Selection svg_padded_axes;
   D3::Selection svg_shifted_axes;
   D3::Selection svg_edited_axis;
+  D3::Selection svg_drawn_axes;
 
   // Scale
   D3::LinearScale scale;
@@ -72,6 +75,7 @@ struct Test_Axis : emp::web::BaseTest {
     D3::Select("#d3_testing_div").Append("div").SetAttr("id", "padded_axes_div");
     D3::Select("#d3_testing_div").Append("div").SetAttr("id", "shifted_axes_div");
     D3::Select("#d3_testing_div").Append("div").SetAttr("id", "edited_axis_div");
+    D3::Select("#d3_testing_div").Append("div").SetAttr("id", "drawn_axes_div");
 
     // set the svg for default axis testing to 600x100px
     svg_default_axis = D3::Select("#default_axis_div").Append("svg").SetAttr("id", "default_axis_svg").SetAttr("width", 600).SetAttr("height", 100);
@@ -83,6 +87,8 @@ struct Test_Axis : emp::web::BaseTest {
     svg_shifted_axes = D3::Select("#shifted_axes_div").Append("svg").SetAttr("id", "shifted_axes_svg").SetAttr("width", 600).SetAttr("height", 200);
     // set the svg for edited axis testing to 600x100px
     svg_edited_axis = D3::Select("#edited_axis_div").Append("svg").SetAttr("id", "edited_axis_svg").SetAttr("width", 600).SetAttr("height", 100);
+    // set the svg for shifted axes testing to 600x600px (taller to fit vertical axis)
+    svg_drawn_axes = D3::Select("#drawn_axes_div").Append("svg").SetAttr("id", "drawn_axes_svg").SetAttr("width", 600).SetAttr("height", 600);
 
     // set up a simple scale that all of the axes will be constructed on
     scale = D3::LinearScale();
@@ -105,6 +111,10 @@ struct Test_Axis : emp::web::BaseTest {
     shifted_labeled_axis = D3::Axis<D3::LinearScale>(30, 55, "top", "Labeled Shifted").SetScale(scale).Draw(svg_shifted_axes);
     // set up axis to test other functions that can be called to edit a default axis
     edited_axis = D3::Axis<D3::LinearScale>("bottom", "Edited Axis").SetScale(scale).Draw(svg_edited_axis);
+    // set up axes to test DrawAxes() function
+    D3::Axis<D3::LinearScale> drawn_bottom_axis = D3::Axis<D3::LinearScale>("bottom", "DrawAxes Bottom", 90).SetScale(scale);
+    D3::Axis<D3::LinearScale> drawn_left_axis = D3::Axis<D3::LinearScale>("left", "DrawAxes Left", 170).SetScale(scale);
+    DrawAxes(drawn_bottom_axis, drawn_left_axis, svg_drawn_axes);
 
     // call various modifying functions on edited_axis to test them
     edited_axis.AdjustLabelOffset("4em");
@@ -398,6 +408,25 @@ struct Test_Axis : emp::web::BaseTest {
         });
         it("should change tick values (set first tick to '1122') and set formatting to ',.2r'", function() {
           chai.assert.equal(e_axis_tick_label.text(), "1,100");
+        });
+
+      });
+
+    });
+
+    // Test axes that are drawn with DrawAxes()
+    EM_ASM({
+
+      describe("Drawn Axes", function() {
+
+        var drawn_b_axis_container = d3.select("#drawn_axes_svg>g:nth-child(1)"); // padding: 90
+        var drawn_l_axis_container = d3.select("#drawn_axes_svg>g:nth-child(2)"); // padding: 170
+
+        it("should position the bottom axis correctly (shifted 170px right and 90px from bottom)", function() {
+          chai.assert.equal(drawn_b_axis_container.attr("transform"), "translate(170,510)");
+        });
+        it("should position the left axis correctly (shifted 170px right and 590px from bottom)", function() {
+          chai.assert.equal(drawn_l_axis_container.attr("transform"), "translate(170,10)");
         });
 
       });


### PR DESCRIPTION
- Fixed bug: in Draw(), if a left axis was being created and its scale range lower limit was not zero, its label would be way off (not centered, sometimes out of the svg); fixed so that label is positioned correctly now
  - Fixed by switching the signs of the range limits if a left axis is being drawn. This works because when setting a range, you're thinking on the y-axis: a more positive number means a lower position on the screen. But since left axis labels are rotated -90, a shift in that same direction (lower position on the screen) is on the x-axis and has to be achieved with a more negative number.
  - Before, the x_divisor changed from 2 to -2 if a left axis was being created. That worked if the lower limit of the range was 0, because dividing by -2 had the same effect as switching the sign of the upper limit of the range (and the 0 made no difference). Now the divisor is just 2 no matter the type of axis.
- Restructured test file (organize creation of objects by test instead of by type)
- Wrote tests for axes created on various scale ranges (particularly those with non-zero lower limits) as well as DrawAxes()