### PR TITLE
Fixup emp::Pow

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,17 @@ COPY . /opt/Empirical
 SHELL ["/bin/bash", "-c"]
 
 # Install.
+# adapted in part from https://askubuntu.com/a/916451
 RUN \
-  apt-get update -y \
+  rm /etc/apt/apt.conf.d/docker-gzip-indexes \
     && \
-  apt-get install -y \
+  apt-get purge apt-show-versions \
+    && \
+  rm /var/lib/apt/lists/*lz4 \
+    && \
+  apt-get -o Acquire::GzipIndexes=false update \
+    && \
+  apt-get install -qq \
     software-properties-common \
     apt-show-versions \
     && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,7 @@ SHELL ["/bin/bash", "-c"]
 RUN \
   apt-get update -y \
     && \
-  apt-get install -y \
-    software-properties-common \
-    apt-show-versions \
+  apt-get install -y software-properties-common \
     && \
   add-apt-repository -y ppa:ubuntu-toolchain-r/test \
     && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,17 +6,10 @@ COPY . /opt/Empirical
 SHELL ["/bin/bash", "-c"]
 
 # Install.
-# adapted in part from https://askubuntu.com/a/916451
 RUN \
-  rm /etc/apt/apt.conf.d/docker-gzip-indexes \
+  apt-get update -y \
     && \
-  apt-get purge apt-show-versions \
-    && \
-  rm /var/lib/apt/lists/*lz4 \
-    && \
-  apt-get -o Acquire::GzipIndexes=false update \
-    && \
-  apt-get install -qq \
+  apt-get install -y \
     software-properties-common \
     apt-show-versions \
     && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,9 @@ SHELL ["/bin/bash", "-c"]
 RUN \
   apt-get update -y \
     && \
-  apt-get install -y software-properties-common \
+  apt-get install -y \
+    software-properties-common \
+    apt-show-versions \
     && \
   add-apt-repository -y ppa:ubuntu-toolchain-r/test \
     && \

--- a/source/tools/math.h
+++ b/source/tools/math.h
@@ -257,19 +257,20 @@ namespace emp {
   /// Uses if constexpr to work around compiler bug in Emscripten (issue #296).
   template<typename T>
   static constexpr T Pow(
-    T base, typename internal::identity<T>::type exp
+    T base, typename identity<T>::type exp
   ) {
     // TODO cpp20, C++20 replace with std::is_constant_evaluated
     // adapted from https://stackoverflow.com/a/62610143
-    #ifdef __GNUC__ // defined for both GCC and clang
+    // exclude clang versions with compiler bug https://reviews.llvm.org/D35190
+    #if defined(__clang__) && __clang_major__>=9 || defined(__GNUC__) && !defined(__clang__)
     // if base is not known at compile time, use std::pow which is faster
     if ( !__builtin_constant_p( base ) ) return std::pow(base, exp); 
     // otherwise, use constexpr-friendly implementations
     else
     #endif
     if constexpr( std::is_integral<T>::value ){
-      return internal::PowIntImpl(base, exp);
-    } else return internal::PowDoubleImpl(base, exp);
+      return 1;
+    } else return 0;
   }
 
   // A fast (O(log p)) integer-power command.

--- a/source/tools/math.h
+++ b/source/tools/math.h
@@ -257,7 +257,7 @@ namespace emp {
   /// Uses if constexpr to work around compiler bug in Emscripten (issue #296).
   template<typename T>
   static constexpr T Pow(
-    T base, typename identity<T>::type exp
+    T base, typename internal::identity<T>::type exp
   ) {
     // TODO cpp20, C++20 replace with std::is_constant_evaluated
     // adapted from https://stackoverflow.com/a/62610143
@@ -269,8 +269,8 @@ namespace emp {
     else
     #endif
     if constexpr( std::is_integral<T>::value ){
-      return 1;
-    } else return 0;
+      return internal::PowIntImpl(base, exp);
+    } else return internal::PowDoubleImpl(base, exp);
   }
 
   // A fast (O(log p)) integer-power command.

--- a/source/tools/math.h
+++ b/source/tools/math.h
@@ -254,9 +254,17 @@ namespace emp {
   /// A fast method for calculating exponents on doubles or integral types.
   /// Uses if constexpr to work around compiler bug in Emscripten (issue #296).
   template<typename T>
-  static constexpr decltype(auto) Pow(
+  static constexpr T Pow(
     T base, typename internal::identity<T>::type exp
   ) {
+    // TODO cpp20, C++20 replace with std::is_constant_evaluated
+    // adapted from https://stackoverflow.com/a/62610143
+    #ifdef __GNUC__ // defined for both GCC and clang
+    // if base is not known at compile time, use std::pow which is faster
+    if ( !__builtin_constant_p( base ) ) return std::pow(base, exp); 
+    // otherwise, use constexpr-friendly implementations
+    else
+    #endif
     if constexpr( std::is_integral<T>::value ){
       return internal::PowIntImpl(base, exp);
     } else return internal::PowDoubleImpl(base, exp);

--- a/source/tools/math.h
+++ b/source/tools/math.h
@@ -220,7 +220,7 @@ namespace emp {
   static constexpr T PowIntImpl(T base, T p) {
     if (p <= 0) return 1;
     if (p & 1) return base * PowIntImpl(base, p-1); // Odd exponent: strip one mulitple off and recurse.
-    return Square( PowIntImpl(base,p/2) );          // Even exponent: calc for half and square result.
+    return emp::Square( PowIntImpl(base,p/2) );          // Even exponent: calc for half and square result.
   }
   } // namespace internal
 
@@ -241,7 +241,9 @@ namespace emp {
   static constexpr double PowDoubleImpl(double base, double exp) {
     // Normally, convert to a base of 2 and then use Pow2.
     // If base is negative, we don't want to deal with imaginary numbers, so use IntPow.
-    return (base > 0) ? Pow2(Log2(base) * exp) : IntPow(base,exp);
+    return (base > 0)
+      ? emp::Pow2(emp::Log2(base) * exp)
+      : emp::IntPow(base,exp);
   }
 
   // adapted from https://stackoverflow.com/a/30836042

--- a/tests/data/DataNode.cc
+++ b/tests/data/DataNode.cc
@@ -255,11 +255,16 @@ TEST_CASE("Test DataStats", "[data]") {
     REQUIRE(data3.GetVariance() == Approx(5.87654));
     REQUIRE(data3.GetStandardDeviation() == Approx(2.42416));
     // skewness calculation: https://www.wolframalpha.com/input/?i=skewness+1%2C2%2C3%2C4%2C5%2C6%2C7%2C8%2C8
-    REQUIRE(data3.GetSkew() == Approx(-0.150986));
+    // allow fallback to less precise constexpr Pow
+    const bool skew_res{ data3.GetSkew() == Approx(-0.150986) || data3.GetSkew() == Approx(-0.151045) };
+    REQUIRE( skew_res );
     // kurtosis calculateion
     // - https://www.wolframalpha.com/input/?i=N%5BKurtosis%5B%7B1%2C+2%2C+3%2C+4%2C+5%2C+6%2C+7%2C+8%2C+8%7D%5D%5D+-+3
     // - https://www.itl.nist.gov/div898/handbook/eda/section3/eda35b.htm
-    REQUIRE(data3.GetKurtosis() == Approx(-1.325383));
+    // allow fallback to less precise constexpr Pow
+    const bool kurtosis_res{ data3.GetKurtosis() == Approx(-1.325383) || data3.GetKurtosis() == Approx(-1.3253830944) };
+    REQUIRE( kurtosis_res );
+    
 }
 
 TEST_CASE("Test histogram", "[data]") {

--- a/tests/data/DataNode.cc
+++ b/tests/data/DataNode.cc
@@ -254,8 +254,12 @@ TEST_CASE("Test DataStats", "[data]") {
     REQUIRE(data3.GetMax() == 8);
     REQUIRE(data3.GetVariance() == Approx(5.87654));
     REQUIRE(data3.GetStandardDeviation() == Approx(2.42416));
-    REQUIRE(data3.GetSkew() == Approx(-0.151045));
-    REQUIRE(data3.GetKurtosis() == Approx(-1.3253830944));
+    // skewness calculation: https://www.wolframalpha.com/input/?i=skewness+1%2C2%2C3%2C4%2C5%2C6%2C7%2C8%2C8
+    REQUIRE(data3.GetSkew() == Approx(-0.150986));
+    // kurtosis calculateion
+    // - https://www.wolframalpha.com/input/?i=N%5BKurtosis%5B%7B1%2C+2%2C+3%2C+4%2C+5%2C+6%2C+7%2C+8%2C+8%7D%5D%5D+-+3
+    // - https://www.itl.nist.gov/div898/handbook/eda/section3/eda35b.htm
+    REQUIRE(data3.GetKurtosis() == Approx(-1.325383));
 }
 
 TEST_CASE("Test histogram", "[data]") {


### PR DESCRIPTION
- use std::pow at runtime ( #279 )
- sidestep Emscripten compiler bug ( #296 )