### PR TITLE
Possibly fix issue of using canvas without pthread

### DIFF
--- a/include/emp/web/Canvas.hpp
+++ b/include/emp/web/Canvas.hpp
@@ -75,6 +75,7 @@ namespace web {
         EM_ASM({
           var cname = UTF8ToString($0);
           var canvas = document.getElementById(cname);
+          emp_i.ctx = canvas.getContext('2d');
         }, id.c_str());
         #endif
       }


### PR DESCRIPTION
I don't know this part of the code particularly well, but this change appears to make everything work without the `-pthread` flag, fixing #412.

Someone who actually knows what they're doing should confirm that this is actually a good fix.