### PR TITLE
Add web test coverage!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,11 @@ tmp/
 
 .vscode/
 
+*/*/coverage_cov*
+coverage_source/*/*
+*/*/default.profraw
+*/*/default.profdata
+
 demos/Avida/Avida
 demos/Avida/web/Avida.js
 demos/Emphatic/Emphatic

--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,6 @@
 	clean clean-dep
 
 test: test-native test-examples test-web
-	make test-native
-	make test-examples
-	make test-web
 
 test-examples: test-native-examples test-web-examples
 

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ test-web-examples:
 	cd examples && make web-test
 
 test-web:
-	cd tests && make test-web
+	cd tests && make test-web-js
 
 ../cookiecutter-empirical-project:
 	cd .. && git clone --recursive https://github.com/devosoft/cookiecutter-empirical-project.git

--- a/include/emp/base/assert_warning.hpp
+++ b/include/emp/base/assert_warning.hpp
@@ -21,15 +21,15 @@
  *     emp_assert_warning(a==5, a);
  *
  *  When compiled in debug mode (i.e., without the -DNDEBUG flag), this will
- *  pring an assertion error and print the value of a.
+ *  spring an assertion error and print the value of a.
  */
 
 #ifndef EMP_ASSERT_WARNING_HPP
 #define EMP_ASSERT_WARNING_HPP
 
-#include "always_assert.hpp"
+#include "always_assert_warning.hpp"
 
-/// NDEBUG hould trigger its EMP equivalent.
+/// NDEBUG should trigger its EMP equivalent.
 #ifdef NDEBUG
 #define EMP_NDEBUG
 #endif
@@ -47,7 +47,7 @@
   /// information on any variables or expressions provided as variadic args.
   /// Note: If NDEBUG is defined, emp_assert_warning() will not do anything.
   /// Due to macro parsing limitations, extra information will not be printed when compiling with MSVC.
-  #define emp_assert_warning(...) emp_always_assert(__VA_ARGS__)
+  #define emp_assert_warning(...) emp_always_assert_warning(__VA_ARGS__)
 
 #endif
 

--- a/include/emp/web/JSWrap.hpp
+++ b/include/emp/web/JSWrap.hpp
@@ -89,7 +89,7 @@ namespace emp {
 
   template <int ARG_ID> static void LoadArg(std::string & arg_var) {
     char * tmp_var = (char *) MAIN_THREAD_EM_ASM_INT({
-        return allocate(intArrayFromString(emp_i.cb_args[$0]), ALLOC_STACK);
+        return allocate(intArrayFromString(emp_i.cb_args[$0]), 'i8', ALLOC_STACK);
       }, ARG_ID);
     arg_var = tmp_var;   // @CAO Do we need to free the memory in tmp_var?
   }
@@ -171,7 +171,7 @@ namespace emp {
         emp_i.curr_obj[UTF8ToString($0)] = "undefined";
       }
       return allocate(intArrayFromString(emp_i.curr_obj[UTF8ToString($0)]),
-                   '18', ALLOC_STACK);
+                   'i8', ALLOC_STACK);
     }, var.c_str());
     arg_var = tmp_var;   // Free memory here?
   }

--- a/include/emp/web/JSWrap.hpp
+++ b/include/emp/web/JSWrap.hpp
@@ -45,13 +45,6 @@
 #include <tuple>
 #include <type_traits>
 
-#include <emscripten/emscripten.h>
-#include <emscripten/threading.h>
-#ifdef __EMSCRIPTEN_PTHREADS__
-#include <pthread.h>
-#endif //  __EMSCRIPTEN_PTHREADS__
-
-
 #include "../base/assert.hpp"
 #include "../base/vector.hpp"
 #include "../datastructs/tuple_struct.hpp"
@@ -96,7 +89,7 @@ namespace emp {
 
   template <int ARG_ID> static void LoadArg(std::string & arg_var) {
     char * tmp_var = (char *) MAIN_THREAD_EM_ASM_INT({
-        return allocate(intArrayFromString(emp_i.cb_args[$0]), 'i8', ALLOC_STACK);
+        return allocate(intArrayFromString(emp_i.cb_args[$0]), ALLOC_STACK);
       }, ARG_ID);
     arg_var = tmp_var;   // @CAO Do we need to free the memory in tmp_var?
   }
@@ -178,7 +171,7 @@ namespace emp {
         emp_i.curr_obj[UTF8ToString($0)] = "undefined";
       }
       return allocate(intArrayFromString(emp_i.curr_obj[UTF8ToString($0)]),
-                      'i8', ALLOC_STACK);
+                   '18', ALLOC_STACK);
     }, var.c_str());
     arg_var = tmp_var;   // Free memory here?
   }
@@ -449,7 +442,11 @@ namespace emp {
     // The following function returns a static callback array; callback ID's all index into
     // this array.
     static emp::vector<JSWrap_Callback_Base *> & CallbackArray() {
+      #ifdef __EMSCRIPTEN_PTHREADS__
       thread_local emp::vector<JSWrap_Callback_Base *> callback_array{nullptr};
+      #else
+      static emp::vector<JSWrap_Callback_Base *> callback_array(1, nullptr);
+      #endif
       return callback_array;
     }
 
@@ -608,7 +605,7 @@ void empCppCallback(const size_t cb_id) {
 
     });
 
-    emscripten_async_queue_on_thread_(
+    emscripten_async_queue_on_thread(
       proxy_pthread_id,
       EM_FUNC_SIG_VI, // VI = no return value, one argument
       (void*) &empDoCppCallback,

--- a/include/emp/web/_MochaTestRunner.hpp
+++ b/include/emp/web/_MochaTestRunner.hpp
@@ -354,7 +354,14 @@ namespace web {
     /// Running a test consumes it (i.e., executing Run a second time will not re-run previously run
     /// tests).
     /// Tests are run in the order they were added.
+    #ifdef __EMSCRIPTEN__
     void Run() { if (test_runners.size()) NextTest(); }
+    #else
+    // When running this code natively, we need to call each test individually because the code
+    // to automatically call the each successive test in sequence only exists in Javascript
+    // (this only matters for test coverage)
+    void Run() { while (test_runners.size()) {NextTest(); PopTest();} }
+    #endif
 
     /// Provide a function for MochaTestRunner to call before each test is created and run.
     /// @param fun a function to be run before each test is created and run

--- a/include/emp/web/_MochaTestRunner.hpp
+++ b/include/emp/web/_MochaTestRunner.hpp
@@ -154,7 +154,10 @@ namespace web {
         test_runners.begin(),
         test_runners.end(),
         [](TestRunner & runner) {
+          #ifdef __EMSCRIPTEN__
+          // Runner will only get marked as done if all the javascript stuff is actually happening
           emp_assert(runner.done);
+          #endif
           if (runner.test != nullptr) runner.test.Delete();
         }
       );

--- a/include/emp/web/init.hpp
+++ b/include/emp/web/init.hpp
@@ -11,6 +11,7 @@
 #define EMP_INIT_H
 
 #include <type_traits>
+#include "emp/base/assert_warning.hpp"
 
 /// If __EMSCRIPTEN__ is defined, initialize everything.  Otherwise create useful stubs.
 #ifdef __EMSCRIPTEN__
@@ -175,22 +176,30 @@ namespace emp {
 
 #else
 
+#define EM_ASM(...)
+#define EM_ASM_ARGS(...)
 #define MAIN_THREAD_EM_ASM(...)
-#define MAIN_THREAD_EM_ASM(...)
+#define MAIN_THREAD_ASYNC_EM_ASM(...)
 #define MAIN_THREAD_EM_ASM_INT(...) 0
 #define MAIN_THREAD_EM_ASM_DOUBLE(...) 0.0
 #define MAIN_THREAD_EM_ASM_INT_V(...) 0
 #define MAIN_THREAD_EM_ASM_DOUBLE_V(...) 0.0
 
+#define emscripten_run_script(...)
+
 #include <fstream>
 
 namespace emp {
   std::ofstream debug_file("debug_file");
+  bool init = false;      // Make sure we only initialize once!
 
   /// Stub for when Emscripten is not in use.
   static bool Initialize() {
     // Nothing to do here yet...
-    static_assert(false, "Emscripten web tools require emcc for compilation (for now).");
+    if (!init) {
+      emp_assert_warning(false && "Warning: you're using Empirical web features but not compiling with emcc. These features will not do anything unless you use emcc.");
+    }
+    init = true;
     return true;
   }
 
@@ -205,6 +214,9 @@ namespace emp {
       if (x == true) return "true";
       else return "false";
     }
+
+    template <typename T>
+    int Live(T x) {return 0;} // Dummy implementation
   }
 
 }

--- a/include/emp/web/js_utils.hpp
+++ b/include/emp/web/js_utils.hpp
@@ -296,6 +296,7 @@ namespace emp {
   //
   // Don't worry about the recurse argument - it's for handling nested arrays
   // internally
+  #ifdef __EMSCRIPTEN__
   template <std::size_t SIZE, typename T>
   void pass_array_to_cpp(emp::array<T, SIZE> & arr, bool recurse = false) {
 
@@ -330,7 +331,14 @@ namespace emp {
     free(buffer);
   }
 
+  #else
+
+  template <std::size_t SIZE, typename T>
+  void pass_array_to_cpp(emp::array<T, SIZE> & arr, bool recurse = false) {;}
+  #endif
+
   /// Same as pass_array_to_cpp, but lets you store values in a vector instead
+  #ifdef __EMSCRIPTEN__
   template <typename T>
   void pass_vector_to_cpp(emp::vector<T> & arr, bool recurse = false) {
 
@@ -360,6 +368,11 @@ namespace emp {
     //Free the memory we allocated in Javascript
     free(buffer);
   }
+
+  #else
+  template <typename T>
+  void pass_vector_to_cpp(emp::vector<T> & arr, bool recurse = false) {;}
+  #endif
 
   /// @cond TEMPLATES
 
@@ -397,6 +410,7 @@ namespace emp {
 
   // Chars aren't one of the types supported by setValue, but by treating them
   // as strings in Javascript we can pass them out to a C++ array
+  #ifdef __EMSCRIPTEN__
   template <std::size_t SIZE>
   void pass_array_to_cpp(emp::array<char, SIZE> & arr, bool recurse = false) {
 
@@ -421,10 +435,14 @@ namespace emp {
 
     free(buffer);
   }
-
+  #else
+  template <std::size_t SIZE>
+  void pass_array_to_cpp(emp::array<char, SIZE> & arr, bool recurse = false) {;}
+  #endif
 
   // Chars aren't one of the types supported by setValue, but by treating them
   // as strings in Javascript we can pass them out to a C++ array
+  #ifdef __EMSCRIPTEN__
   void pass_vector_to_cpp(emp::vector<char> & arr, bool recurse = false) {
 
     char * buffer = (char *) MAIN_THREAD_EM_ASM_INT({
@@ -445,8 +463,12 @@ namespace emp {
 
     free(buffer);
   }
+  #else
+  void pass_vector_to_cpp(emp::vector<char> & arr, bool recurse = false) {;}
+  #endif
 
   // We can handle strings in a similar way
+  #ifdef __EMSCRIPTEN__
   template <std::size_t SIZE>
   void pass_array_to_cpp(emp::array<std::string, SIZE> & arr, bool recurse = false) {
 
@@ -483,8 +505,13 @@ namespace emp {
 
     free(buffer);
   }
+  #else
+  template <std::size_t SIZE>
+  void pass_array_to_cpp(emp::array<std::string, SIZE> & arr, bool recurse = false) {;}
+  #endif
 
   // We can handle strings in a similar way
+  #ifdef __EMSCRIPTEN__
   void pass_vector_to_cpp(emp::vector<std::string> & arr, bool recurse = false) {
 
     char * buffer = (char *) MAIN_THREAD_EM_ASM_INT({
@@ -518,8 +545,12 @@ namespace emp {
 
     free(buffer);
   }
+  #else
+  void pass_vector_to_cpp(emp::vector<std::string> & arr, bool recurse = false) {;}
+  #endif
 
   // We can handle nested arrays through recursive calls on chunks of them
+  #ifdef __EMSCRIPTEN__
   template <std::size_t SIZE, std::size_t SIZE2, typename T>
   void pass_array_to_cpp(emp::array<emp::array<T, SIZE2>, SIZE> & arr, bool recurse = false) {
 
@@ -545,8 +576,13 @@ namespace emp {
     if (recurse == 0) { MAIN_THREAD_EM_ASM({emp_i.__temp_array = [];}); }
     else { MAIN_THREAD_EM_ASM({emp_i.__temp_array.pop();}); }
   }
+  #else
+  template <std::size_t SIZE, std::size_t SIZE2, typename T>
+  void pass_array_to_cpp(emp::array<emp::array<T, SIZE2>, SIZE> & arr, bool recurse = false) {;}
+  #endif
 
   /// We can handle nested arrays through recursive calls on chunks of them
+  #ifdef __EMSCRIPTEN__
   template <typename T>
   void pass_vector_to_cpp(emp::vector<emp::vector<T> > & arr, bool recurse = false) {
 
@@ -580,6 +616,10 @@ namespace emp {
       MAIN_THREAD_EM_ASM({emp_i.__temp_array.pop();});
     }
   }
+  #else
+  template <typename T>
+  void pass_vector_to_cpp(emp::vector<emp::vector<T> > & arr, bool recurse = false) {;}
+  #endif
 
   /// @endcond
 
@@ -605,6 +645,7 @@ namespace emp {
     });
 
     // check to make sure each key is not an object or a function
+    #ifdef __EMSCRIPTEN__
     emp_assert(
         MAIN_THREAD_EM_ASM_INT({
           emp_i.__incoming_map_keys.forEach(function(key) {
@@ -612,6 +653,7 @@ namespace emp {
           });
           return 1;
         }), "Keys cannot be an object or a function");
+    #endif
 
     // pass in extracted values vector to JS
     emp::pass_array_to_javascript(values);
@@ -647,6 +689,7 @@ namespace emp {
     });
 
     // check to make sure each key is not an object or a function
+    #ifdef __EMSCRIPTEN__
     emp_assert(
         MAIN_THREAD_EM_ASM_INT({
           emp_i.__incoming_map_keys.forEach(function(key) {
@@ -654,6 +697,7 @@ namespace emp {
           });
           return 1;
         }), "Keys cannot be an object or a function");
+    #endif
 
     // pass in values vector to JS
     emp::pass_array_to_javascript(values);

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,4 +1,4 @@
-TEST_NAMES := base bits compiler config control data datastructs debug Evolve functional games geometry hardware io matching math meta scholar testing tools
+TEST_NAMES := base bits compiler config control data datastructs debug Evolve functional games geometry hardware io matching math meta scholar testing tools web
 
 CXX = clang++
 #CXX := g++
@@ -34,7 +34,7 @@ cranky-%:
 cranky: $(addprefix cranky-, $(TEST_NAMES))
 
 test-web:
-	  cd web && make test
+	cd web && make test
 
 clean: $(addprefix clean-, $(TEST_NAMES)) clean-web
 	rm -f *.out

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -33,7 +33,7 @@ cranky-%:
 
 cranky: $(addprefix cranky-, $(TEST_NAMES))
 
-test-web:
+test-web-js:
 	cd web && make test-web
 
 clean: $(addprefix clean-, $(TEST_NAMES)) clean-web

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -34,7 +34,7 @@ cranky-%:
 cranky: $(addprefix cranky-, $(TEST_NAMES))
 
 test-web:
-	cd web && make test
+	cd web && make test-web
 
 clean: $(addprefix clean-, $(TEST_NAMES)) clean-web
 	rm -f *.out

--- a/tests/web/Makefile
+++ b/tests/web/Makefile
@@ -19,14 +19,16 @@ OFLAGS_web_braces := -pedantic -Wno-dollar-in-identifier-extension -s TOTAL_MEMO
 
 CFLAGS_web := $(CFLAGS_all) $(OFLAGS_web_braces) --js-library ../../include/emp/web/library_emp.js --js-library ../../include/emp/web/d3/library_d3.js -s EXPORTED_FUNCTIONS="['_main', '_empCppCallback']" -s DISABLE_EXCEPTION_CATCHING=1 -s NO_EXIT_RUNTIME=1 -s EXTRA_EXPORTED_RUNTIME_METHODS='["ccall", "cwrap", "stringToUTF8"]' -s WASM=0
 
-test: $(addprefix test-, $(TEST_NAMES)) test-color_map test-GetUrlParams fulldebug opt cranky
+test-web: $(addprefix test-web, $(TEST_NAMES)) test-GetUrlParams
 
-test-%: %.cpp
+test-web-%: %.cpp
 	source ../../third-party/emsdk/emsdk_env.sh; \
 	$(CXX_web) $(CFLAGS_web) $< -o $@.js
 	cp ../../third-party/package.json .
 	npm install
 	../../third-party/node_modules/karma/bin/karma start karma.conf.js --filename $@
+
+test: $(addprefix test-native, $(TEST_NAMES)) test-color_map
 
 test-native-%: %.cpp 
 	$(CXX) $(CFLAGS_all) $< -lstdc++fs -o $@.out

--- a/tests/web/Makefile
+++ b/tests/web/Makefile
@@ -1,6 +1,6 @@
 SHELL := /bin/bash
 
-TEST_NAMES = ConfigPanel Collapse LoadingModal Card CommentBox Modal ToggleSwitch CodeBlock LoadingIcon FontAwesomeIcon ClickCounterDemo ClickCollapseDemo Element TextFeed js_utils visualizations JSWrap Widget
+TEST_NAMES = ConfigPanel Collapse LoadingModal Card CommentBox Modal ToggleSwitch CodeBlock LoadingIcon FontAwesomeIcon ClickCounterDemo ClickCollapseDemo Element TextFeed js_utils JSWrap Widget
 
 # Currently a couple of the tests won't compile to native so this is a separate list for now. Eventually we should fix
 # that and just have one list

--- a/tests/web/Makefile
+++ b/tests/web/Makefile
@@ -19,7 +19,7 @@ OFLAGS_web_braces := -pedantic -Wno-dollar-in-identifier-extension -s TOTAL_MEMO
 
 CFLAGS_web := $(CFLAGS_all) $(OFLAGS_web_braces) --js-library ../../include/emp/web/library_emp.js --js-library ../../include/emp/web/d3/library_d3.js -s EXPORTED_FUNCTIONS="['_main', '_empCppCallback']" -s DISABLE_EXCEPTION_CATCHING=1 -s NO_EXIT_RUNTIME=1 -s EXTRA_EXPORTED_RUNTIME_METHODS='["ccall", "cwrap", "stringToUTF8"]' -s WASM=0
 
-test-web: $(addprefix test-web, $(TEST_NAMES)) test-GetUrlParams
+test-web-: $(addprefix test-web-, $(TEST_NAMES)) test-GetUrlParams
 
 test-web-%: %.cpp
 	source ../../third-party/emsdk/emsdk_env.sh; \

--- a/tests/web/Makefile
+++ b/tests/web/Makefile
@@ -2,6 +2,10 @@ SHELL := /bin/bash
 
 TEST_NAMES = ConfigPanel Collapse LoadingModal Card CommentBox Modal ToggleSwitch CodeBlock LoadingIcon FontAwesomeIcon ClickCounterDemo ClickCollapseDemo Element TextFeed js_utils visualizations JSWrap Widget
 
+# Currently a couple of the tests won't compile to native so this is a separate list for now. Eventually we should fix
+# that and just have one list
+NATIVE_TEST_NAMES = ConfigPanel LoadingModal Card CommentBox Modal ToggleSwitch CodeBlock LoadingIcon FontAwesomeIcon ClickCounterDemo Element TextFeed js_utils JSWrap Widget
+
 # Flags to use regardless of compiler
 CFLAGS_all := -Wall -Wno-unused-function -Wno-gnu-zero-variadic-macro-arguments -Wno-dollar-in-identifier-extension -std=c++17 -I../../include/ -I../../
 
@@ -15,7 +19,7 @@ OFLAGS_web_braces := -pedantic -Wno-dollar-in-identifier-extension -s TOTAL_MEMO
 
 CFLAGS_web := $(CFLAGS_all) $(OFLAGS_web_braces) --js-library ../../include/emp/web/library_emp.js --js-library ../../include/emp/web/d3/library_d3.js -s EXPORTED_FUNCTIONS="['_main', '_empCppCallback']" -s DISABLE_EXCEPTION_CATCHING=1 -s NO_EXIT_RUNTIME=1 -s EXTRA_EXPORTED_RUNTIME_METHODS='["ccall", "cwrap", "stringToUTF8"]' -s WASM=0
 
-test: $(addprefix test-, $(TEST_NAMES)) test-color_map test-GetUrlParams
+test: $(addprefix test-, $(TEST_NAMES)) test-color_map test-GetUrlParams fulldebug opt cranky
 
 test-%: %.cpp
 	source ../../third-party/emsdk/emsdk_env.sh; \
@@ -23,6 +27,11 @@ test-%: %.cpp
 	cp ../../third-party/package.json .
 	npm install
 	../../third-party/node_modules/karma/bin/karma start karma.conf.js --filename $@
+
+test-native-%: %.cpp 
+	$(CXX) $(CFLAGS_all) $< -lstdc++fs -o $@.out
+	# execute test
+	./$@.out
 
 test-color_map: color_map.cpp ../../third-party/Catch/single_include/catch2/catch.hpp
 	g++ $(CFLAGS_all) color_map.cpp -o color_map.out
@@ -36,6 +45,33 @@ test-GetUrlParams: GetUrlParams.cpp
 ../../third-party/Catch/single_include/catch2/catch.hpp:
 	git submodule init
 	git submodule update
+
+cov-%: %.cpp ../../third-party/Catch/single_include/catch2/catch.hpp
+	$(CXX) $(CFLAGS_all) $< -lstdc++fs -o $@.out
+	#echo "running $@.out"
+	# execute test
+	./$@.out
+	llvm-profdata merge default.profraw -o default.profdata
+	llvm-cov show ./$@.out -instr-profile=default.profdata > coverage_$@.txt
+	python ../../third-party/force-cover/fix_coverage.py coverage_$@.txt
+
+coverage: CFLAGS_all := -std=c++17 -pthread -g -Wall -Wno-unused-function -I../../coverage_source/ -I../../ -I../../third-party/cereal/include/ -DEMP_TRACK_MEM -Wnon-virtual-dtor -Wcast-align -Woverloaded-virtual -ftemplate-backtrace-limit=0 -fprofile-instr-generate -fcoverage-mapping -fno-inline -fno-elide-constructors -O0
+coverage: $(addprefix cov-, $(NATIVE_TEST_NAMES))
+
+# Test in debug mode with pointer tracking
+fulldebug: CFLAGS_all := -std=c++17 -pthread -g -Wall -Wno-unused-function -I../../include/ -I../../third-party/cereal/include/ -I../../ -pedantic -DEMP_TRACK_MEM -Wnon-virtual-dtor -Wcast-align -Woverloaded-virtual -ftemplate-backtrace-limit=0 # -Wmisleading-indentation
+fulldebug: $(addprefix test-native-, $(NATIVE_TEST_NAMES))
+	rm -rf test*.out
+
+# Test optimized version without debug features
+opt: FLAGS := -std=c++17 -pthread -DNDEBUG -O3 -Wno-unused-function -I../../include/ -I../../third-party/cereal/include/ -I../../
+opt: $(addprefix test-, $(NATIVE_TEST_NAMES))
+	rm -rf test*.out
+
+cranky: FLAGS := -std=c++17 -pthread -g -Wall -Wno-unused-function -I../../include/ -I../../third-party/cereal/include/ -I../../ -pedantic -DEMP_TRACK_MEM -Wnon-virtual-dtor -Wcast-align -Woverloaded-virtual -Wconversion -Weffc++
+cranky: $(addprefix test-, $(NATIVE_TEST_NAMES))
+	rm -rf test*.out
+
 
 clean:
 	rm -f *.js.map *.js.mem *~ color_map.out

--- a/tests/web/Makefile
+++ b/tests/web/Makefile
@@ -1,6 +1,6 @@
 SHELL := /bin/bash
 
-TEST_NAMES = ConfigPanel Collapse LoadingModal Card CommentBox Modal ToggleSwitch CodeBlock LoadingIcon FontAwesomeIcon ClickCounterDemo ClickCollapseDemo Element TextFeed js_utils JSWrap Widget
+TEST_NAMES = ConfigPanel Collapse LoadingModal Card CommentBox Modal ToggleSwitch CodeBlock LoadingIcon FontAwesomeIcon ClickCounterDemo ClickCollapseDemo Element TextFeed js_utils JSWrap Widget visualizations
 
 # Currently a couple of the tests won't compile to native so this is a separate list for now. Eventually we should fix
 # that and just have one list

--- a/tests/web/Makefile
+++ b/tests/web/Makefile
@@ -67,17 +67,16 @@ fulldebug: $(addprefix test-native-, $(NATIVE_TEST_NAMES))
 
 # Test optimized version without debug features
 opt: FLAGS := -std=c++17 -pthread -DNDEBUG -O3 -Wno-unused-function -I../../include/ -I../../third-party/cereal/include/ -I../../
-opt: $(addprefix test-, $(NATIVE_TEST_NAMES))
+opt: $(addprefix test-native-, $(NATIVE_TEST_NAMES))
 	rm -rf test*.out
 
 cranky: FLAGS := -std=c++17 -pthread -g -Wall -Wno-unused-function -I../../include/ -I../../third-party/cereal/include/ -I../../ -pedantic -DEMP_TRACK_MEM -Wnon-virtual-dtor -Wcast-align -Woverloaded-virtual -Wconversion -Weffc++
-cranky: $(addprefix test-, $(NATIVE_TEST_NAMES))
+cranky: $(addprefix test-native-, $(NATIVE_TEST_NAMES))
 	rm -rf test*.out
-
 
 clean:
 	rm -f *.js.map *.js.mem *~ color_map.out
-	ls *.js | grep -v karma.conf.js | xargs rm
+	ls *.js | grep -v karma.conf.js | xargs rm || true
 
 # Debugging information
 #print-%: ; @echo $*=$($*)

--- a/tests/web/Makefile
+++ b/tests/web/Makefile
@@ -28,7 +28,7 @@ test-web-%: %.cpp
 	npm install
 	../../third-party/node_modules/karma/bin/karma start karma.conf.js --filename $@
 
-test: $(addprefix test-native, $(TEST_NAMES)) test-color_map
+test: $(addprefix test-native-, $(NATIVE_TEST_NAMES)) test-color_map
 
 test-native-%: %.cpp 
 	$(CXX) $(CFLAGS_all) $< -lstdc++fs -o $@.out

--- a/tests/web/Makefile
+++ b/tests/web/Makefile
@@ -19,7 +19,7 @@ OFLAGS_web_braces := -pedantic -Wno-dollar-in-identifier-extension -s TOTAL_MEMO
 
 CFLAGS_web := $(CFLAGS_all) $(OFLAGS_web_braces) --js-library ../../include/emp/web/library_emp.js --js-library ../../include/emp/web/d3/library_d3.js -s EXPORTED_FUNCTIONS="['_main', '_empCppCallback']" -s DISABLE_EXCEPTION_CATCHING=1 -s NO_EXIT_RUNTIME=1 -s EXTRA_EXPORTED_RUNTIME_METHODS='["ccall", "cwrap", "stringToUTF8"]' -s WASM=0
 
-test-web-: $(addprefix test-web-, $(TEST_NAMES)) test-GetUrlParams
+test-web: $(addprefix test-web-, $(TEST_NAMES)) test-GetUrlParams
 
 test-web-%: %.cpp
 	source ../../third-party/emsdk/emsdk_env.sh; \

--- a/tests/web/js_utils.cpp
+++ b/tests/web/js_utils.cpp
@@ -221,81 +221,107 @@ struct TestPassArrayToCpp : public emp::web::BaseTest {
     EM_ASM({emp_i.__outgoing_array = ([5, 1, 3])});
     emp::array<int, 3> test_arr_1;
     emp::pass_array_to_cpp(test_arr_1);
+
+    #ifdef __EMSCRIPTEN__
     assert(test_arr_1[0] == 5);
     assert(test_arr_1[1] == 1);
     assert(test_arr_1[2] == 3);
+    #endif
 
     // Test floats
     EM_ASM({emp_i.__outgoing_array = ([5.2, 1.5, 3.1])});
     emp::array<float, 3> test_arr_2;
     emp::pass_array_to_cpp(test_arr_2);
+
+    #ifdef __EMSCRIPTEN__
     assert(emp::to_string(test_arr_2[0]) == emp::to_string(5.2));
     assert(test_arr_2[1] == 1.5);
     assert(emp::to_string(test_arr_2[2]) == emp::to_string(3.1));
+    #endif 
 
     // Test doubles
     EM_ASM({emp_i.__outgoing_array = ([5.2, 1.5, 3.1])});
     emp::array<double, 3> test_arr_3;
     emp::pass_array_to_cpp(test_arr_3);
+
+    #ifdef __EMSCRIPTEN__
     assert(test_arr_3[0] == 5.2);
     assert(test_arr_3[1] == 1.5);
     assert(test_arr_3[2] == 3.1);
+    #endif
 
     // Test doubles in vector
     EM_ASM({emp_i.__outgoing_array = ([5.3, 1.6, 3.2])});
     emp::vector<double> test_vec;
     emp::pass_vector_to_cpp(test_vec);
+
+    #ifdef __EMSCRIPTEN__
     assert(test_vec[0] == 5.3);
     assert(test_vec[1] == 1.6);
     assert(test_vec[2] == 3.2);
+    #endif
 
     // Test chars
     EM_ASM({emp_i.__outgoing_array = (["h", "i", "!"])});
     emp::array<char, 3> test_arr_4;
     emp::pass_array_to_cpp(test_arr_4);
+    #ifdef __EMSCRIPTEN__
     assert(test_arr_4[0] == 'h');
     assert(test_arr_4[1] == 'i');
     assert(test_arr_4[2] == '!');
+    #endif
+
     emp::vector<char> test_vec_4;
     emp::pass_vector_to_cpp(test_vec_4);
+    #ifdef __EMSCRIPTEN__
     assert(test_vec_4[0] == 'h');
     assert(test_vec_4[1] == 'i');
     assert(test_vec_4[2] == '!');
+    #endif
 
     // Test std::strings
     EM_ASM({emp_i.__outgoing_array = (["jello", "world", "!!"])});
     emp::array<std::string, 3> test_arr_5;
     emp::pass_array_to_cpp(test_arr_5);
+    #ifdef __EMSCRIPTEN__
     assert(test_arr_5[0] == "jello");
     assert(test_arr_5[1] == "world");
     assert(test_arr_5[2] == "!!");
+    #endif
+
     emp::vector<std::string> test_vec_5;
     emp::pass_vector_to_cpp(test_vec_5);
+    #ifdef __EMSCRIPTEN__
     assert(test_vec_5[0] == "jello");
     assert(test_vec_5[1] == "world");
     assert(test_vec_5[2] == "!!");
+    #endif
 
     // Test nested arrays
     EM_ASM({emp_i.__outgoing_array = ([[4,5], [3,1], [7,8]])});
     emp::array<emp::array<int, 2>, 3> test_arr_6;
     emp::pass_array_to_cpp(test_arr_6);
+    #ifdef __EMSCRIPTEN__
     assert(test_arr_6[0][0] == 4);
     assert(test_arr_6[0][1] == 5);
     assert(test_arr_6[1][0] == 3);
     assert(test_arr_6[1][1] == 1);
     assert(test_arr_6[2][0] == 7);
     assert(test_arr_6[2][1] == 8);
+    #endif
 
     // Test nested vectors
     EM_ASM({emp_i.__outgoing_array = ([[4,5], [3,1], [7,8]])});
     emp::vector<emp::vector<int> > test_vec_6;
     emp::pass_vector_to_cpp(test_vec_6);
+    #ifdef __EMSCRIPTEN__
     assert(test_vec_6[0][0] == 4);
     assert(test_vec_6[0][1] == 5);
     assert(test_vec_6[1][0] == 3);
     assert(test_vec_6[1][1] == 1);
     assert(test_vec_6[2][0] == 7);
     assert(test_vec_6[2][1] == 8);
+    #endif
 
     // Test more deeply nested arrays
     EM_ASM({emp_i.__outgoing_array = ([[["Sooo", "many"], ["strings", "here"]],
@@ -303,6 +329,7 @@ struct TestPassArrayToCpp : public emp::web::BaseTest {
       [["in", "this"], ["nested", "array!"]]]);});
     emp::array<emp::array<emp::array<std::string, 2>, 2>, 3> test_arr_7;
     emp::pass_array_to_cpp(test_arr_7);
+    #ifdef __EMSCRIPTEN__
     assert(test_arr_7[0][0][0] == "Sooo");
     assert(test_arr_7[0][0][1] == "many");
     assert(test_arr_7[0][1][0] == "strings");
@@ -315,6 +342,7 @@ struct TestPassArrayToCpp : public emp::web::BaseTest {
     assert(test_arr_7[2][0][1] == "this");
     assert(test_arr_7[2][1][0] == "nested");
     assert(test_arr_7[2][1][1] == "array!");
+    #endif
   }
 
 };


### PR DESCRIPTION
Finally! A (imperfect but pretty decent) solution to #184! Honestly I'm feeling a bit silly about the fact that I've been thinking about this problem for 3+ years and didn't think of this.

The solution is to compile all of the web tests natively and use the exact same test infrastructure we're using everywhere else. Early on in Empirical's development, there was an idea that we should make code that interfaces with Javascript be able to be compiled natively (obviously it won't do anything, but it should compile). This is enabled by the handy macro stubs in `include/emp/web/init.hpp`. However, we've mostly kept web code separate from native code, as enforced by the `static_asset` discussed in #199. There are a lot of good reasons to usually keep them separate, but there are some clear use cases for not keeping them separate as well. Notably this one.

Specifically, this pull request does the following:
- Replaces the static_assert in init.hpp with a warning instead (as I proposed in my comment on #199)
- Makes a couple of fixes to warnings to make that possible (they seem to be a little broken, currently)
- Adds a couple new stubs to emp/web/init.hpp.
- Changes the makefiles to also compile and run all of the web tests natively, using g++ and clang, and to have coverage measured exactly like it is for all of the other native tests.
- Adds a few `#ifdef __EMSCRIPTEN__` guards associated with emp/web/js_utils.hpp. Everywhere also was fine, but js_utils goes back and forth between C++ and Javascript enough that it causes problems trying to run the code natively. In a few places I had to make alternative dummy versions of functions that couldn't possibly run without Javascript.
- Adds a native mode to the Mocha test runner to make sure all of the tests get run when there's no Javascript.
- Cleans up a couple pthread things in JSWrap that were causing errors.

If you take a look at the CodeCov report, you'll see that this works!

The caveats to be aware of are:
- Any C++ code that only gets called from Javascript will be marked as not covered (because there isn't a way to know if it runs). This looks like it's mostly JSWrapped functions.
- Any pure Javascript embedded in the C++ will either be counted as covered or treated as if it cannot be covered, despite the fact that we actually just have no idea if it's covered.
- This approach does require us to be a little more fastidious about making sure all code can be compiled natively, but I think that's probably worthwhile anyway.
- In situations where functions need a dummy version for native compilation, the real version (`#ifdef __EMSCRIPTEN__`ed out) will be marked as not needing to be covered. However, the dummy version will show up as either covered or not covered, which at least tells us whether the function was called. It's not line-level coverage information, but it's something.
- This is testing our C++ wrapper, not the Javascript inside. That said, if we always run these tests both natively and in Javascript (as we're currently doing), the coverage information from the native code combined with the lack of errors from the Javascript code can give us a decent level of confidence that the Javascript part of covered lines works.

Things to check before this gets merged:
- Are there any objections to replacing the static_assert in init.hpp with a warning?
- Am I doing anything bad with the fixes to warnings and/or the fixes to JSWrap?
- Any other concerns?