### PR TITLE
Pin ubuntu version to 18.04 in the CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   test:
     name: Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     strategy:
       matrix:
         cxx: [clang++, g++]
@@ -37,7 +37,7 @@ jobs:
           make ${TEST_SET} CXX=${CXX}
   test-web:
     name: Web Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
         with:
@@ -51,7 +51,7 @@ jobs:
           run: make test-web
   test-coverage:
     name: Measure Test Coverage
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
         with:
@@ -74,7 +74,7 @@ jobs:
       - run: curl -s https://codecov.io/bash | bash
   test-documentation:
     name: Test Documentation Build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
         with:
@@ -91,7 +91,7 @@ jobs:
           dst: stats/doc-coverage.json          
   deploy-dockerhub:
     name: Deploy to DockerHub
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     if: github.ref == 'refs/heads/master'
     needs:
       - test


### PR DESCRIPTION
Github actions was failing because of a recent issue with ubuntu-latest, pinning to this version fixed.