### PR TITLE
More extensive tests of config behavior

### DIFF
--- a/tests/config/config.cpp
+++ b/tests/config/config.cpp
@@ -20,8 +20,23 @@ TEST_CASE("Test config", "[config]"){
 
   // test config class template
   {
-
+    
     MyConfig config;
+
+    // make sure printing/parsing do not alter config
+    std::stringstream ss1, ss2;
+    config.Write(ss1);
+    config.Read(ss1);
+    config.Write(ss2);
+    std::string l1, l2;
+    while ( ss1 && ss2 ) {
+      std::getline(ss1, l1);
+      std::getline(ss2, l2);
+      // Check every line is the same between the "files"
+      REQUIRE(l1 == l2);
+    }
+
+
     config.Read("assets/test.cfg");
 
     std::cout << "Random seed = " << config.RANDOM_SEED() << std::endl;


### PR DESCRIPTION
I've noticed quite a few bugs and discrepancies between the initialization of a config file via a `.hpp` and reading from a `.cfg` format and just some bugs with handling data. I've added some new tests that reveal bugs and hopefully can catch future problems.