### PR TITLE
More prefab modifications

### DIFF
--- a/include/emp/config/config.hpp
+++ b/include/emp/config/config.hpp
@@ -21,6 +21,7 @@
  *  load settings from a file:         config.Read(filename);
  *  save settings to a stream:         config.Write(stream);
  *  save settings to a file:           config.Write(filename);
+ *  generate a query string:           config.WriteUrlQueryString(stream)
  *
  *  write settings macros to a stream: config.WriteMacros(stream);
  *  write settings macros to a file:   config.WriteMacros(filename);
@@ -126,7 +127,17 @@ namespace emp {
       std::string GetValue() const { return emp::to_string(entry_ref); }
       std::string GetLiteralValue() const { return to_literal(entry_ref); }
       ConfigEntry & SetValue(const std::string & in_val, std::stringstream & /* warnings */) {
-        std::stringstream ss; ss << in_val; ss >> entry_ref; return *this;
+        if constexpr (std::is_same<VAR_TYPE, std::string>::value) {
+          // Using a stringstream on a string with whitespace will only get
+          // first word, so only right trim for extra white space
+          size_t end = in_val.find_last_not_of(" \n\r\t\f\v");
+          entry_ref = (end == std::string::npos) ? "" : in_val.substr(0, end+1);
+        } else {
+          // For other values, use the power of a stringstream to do a quick
+          // conversion
+          std::stringstream ss; ss << in_val; ss >> entry_ref;
+        }
+        return *this;
       }
       bool IsConst() const { return false; }
     };
@@ -236,6 +247,15 @@ namespace emp {
         }
 
         out << std::endl; // Skip a line after each group.
+      }
+
+      void WriteUrlQueryString(std::ostream & out) const {
+        for (auto entry : entry_set) {
+          out << url_encode<false>(entry->GetName());
+          out << "=";
+          out << url_encode<false>(entry->GetValue());
+          out << "&";
+        }
       }
 
       void WriteMacros(std::ostream & out, bool as_const) const {
@@ -468,6 +488,19 @@ namespace emp {
       std::ofstream out(filename);
       Write(out);
       out.close();
+    }
+
+    // Generates url query parameters for the state of Config
+    void WriteUrlQueryString(std::ostream & out) const {
+      std::stringstream ss;
+      ss << "?";
+      for (auto it = group_set.begin(); it != group_set.end(); it++) {
+        (*it)->WriteUrlQueryString(ss);
+      }
+      std::string query(ss.str());
+      // Erase the trailing & to prevent parsing as an illegal (empty) argument to query
+      query.erase(query.end()-1);
+      out << query;
     }
 
     // Generate a text representation (typically a file) for the state of Config

--- a/include/emp/config/config.hpp
+++ b/include/emp/config/config.hpp
@@ -21,7 +21,7 @@
  *  load settings from a file:         config.Read(filename);
  *  save settings to a stream:         config.Write(stream);
  *  save settings to a file:           config.Write(filename);
- *  generate a query string:           config.WriteUrlQueryString(stream)
+ *  generate a query string:           config.WriteUrlQueryString(stream);
  *
  *  write settings macros to a stream: config.WriteMacros(stream);
  *  write settings macros to a file:   config.WriteMacros(filename);

--- a/include/emp/prefab/Card.hpp
+++ b/include/emp/prefab/Card.hpp
@@ -39,8 +39,8 @@ namespace prefab {
 
       AddBootstrap();
       if (state == "STATIC") { // static card with no toggle enabled
-        *this << card_header;
-        *this << card_body;
+        ((emp::web::Widget) *this) << card_header; // Widget cast prevents trying to add to body
+        ((emp::web::Widget) *this) << card_body;
       } else {
         // card is collapsible, make the collapse link the head of the card
         prefab::CollapseCoupling accordion(card_header,
@@ -48,8 +48,8 @@ namespace prefab {
           state == "INIT_OPEN",
           emp::to_string(card_base+ "_card_collapse")
         );
-        *this << accordion.GetControllerDiv();
-        *this << accordion.GetTargetDiv();
+        ((emp::web::Widget) *this) << accordion.GetControllerDiv();
+        ((emp::web::Widget) *this) << accordion.GetTargetDiv();
 
         if (show_glyphs) { // by default add glyphs to a collapsible card
           prefab::FontAwesomeIcon up("fa-angle-double-up");
@@ -95,17 +95,23 @@ namespace prefab {
      * Add content to body section of card
      *
      * @param val can be a web element or primitive type
+     * @deprecated Use stream operator instead
      */
     template <typename T>
     void AddBodyContent(T val) {
       card_body << val;
     }
 
-    /*
-     * TODO: override operator<< so that it streams into body of card
-     * Methods tried so far (without success) are listed in
-     * Issue #345 (https://github.com/devosoft/Empirical/issues/345)
+    /**
+     * Add content to the body section of the card
+     * 
+     * @param in_val can be a web element or primitive type
      */
+    template <typename IN_TYPE> emp::prefab::Card & operator<<(IN_TYPE && in_val) {
+      card_body << std::forward<IN_TYPE>(in_val);
+      return (*this);
+    }
+
   };
 }
 }

--- a/include/emp/prefab/Card.hpp
+++ b/include/emp/prefab/Card.hpp
@@ -39,8 +39,8 @@ namespace prefab {
 
       AddBootstrap();
       if (state == "STATIC") { // static card with no toggle enabled
-        ((emp::web::Widget) *this) << card_header; // Widget cast prevents trying to add to body
-        ((emp::web::Widget) *this) << card_body;
+        ((emp::web::Div) *this) << card_header; // Div cast prevents trying to add to body
+        ((emp::web::Div) *this) << card_body;
       } else {
         // card is collapsible, make the collapse link the head of the card
         prefab::CollapseCoupling accordion(card_header,
@@ -48,8 +48,8 @@ namespace prefab {
           state == "INIT_OPEN",
           emp::to_string(card_base+ "_card_collapse")
         );
-        ((emp::web::Widget) *this) << accordion.GetControllerDiv();
-        ((emp::web::Widget) *this) << accordion.GetTargetDiv();
+        ((emp::web::Div) *this) << accordion.GetControllerDiv();
+        ((emp::web::Div) *this) << accordion.GetTargetDiv();
 
         if (show_glyphs) { // by default add glyphs to a collapsible card
           prefab::FontAwesomeIcon up("fa-angle-double-up");

--- a/include/emp/prefab/Card.hpp
+++ b/include/emp/prefab/Card.hpp
@@ -98,13 +98,14 @@ namespace prefab {
      * @deprecated Use stream operator instead
      */
     template <typename T>
+    [[deprecated("Use the stream operator (<<) to add to card body")]]
     void AddBodyContent(T val) {
       card_body << val;
     }
 
     /**
      * Add content to the body section of the card
-     * 
+     *
      * @param in_val can be a web element or primitive type
      */
     template <typename IN_TYPE> emp::prefab::Card & operator<<(IN_TYPE && in_val) {

--- a/include/emp/prefab/ConfigPanel.hpp
+++ b/include/emp/prefab/ConfigPanel.hpp
@@ -347,7 +347,7 @@ namespace prefab {
         const std::string & div_name = "settings_div"
       ) : config(c) {
         info = new internal::ConfigPanelInfo(div_name);
-        settings_div.SetCSS("display", "flex", "flex-direction", "column");
+        this->SetCSS("display", "flex", "flex-direction", "column");
       }
 
       /**
@@ -507,7 +507,7 @@ namespace prefab {
          }, "Reset with changes", "settings_reset"};
         reset_button.SetAttr("class", "btn btn-danger");
         reset_button.SetCSS("order", "1", "margin-left", "auto");
-        settings_div << reset_button;
+        (*this) << reset_button;
       }
 
       /** @return Div containing the entire config panel

--- a/include/emp/prefab/ConfigPanel.hpp
+++ b/include/emp/prefab/ConfigPanel.hpp
@@ -107,7 +107,7 @@ namespace prefab {
 
       inline static std::set<std::string> numeric_types = {"int", "double", "float", "uint32_t", "uint64_t", "size_t"};
       Config & config;
-      std::set<std::string> excluded_individuals;
+      std::set<std::string> excluded_settings;
       std::set<std::string> excluded_groups;
       std::map<std::string, web::Div> input_divs;
 
@@ -399,9 +399,16 @@ namespace prefab {
         // Otherwise val is 0 and we have nothing to go on
       }
 
-
+      /**
+       * Excludes a setting or group of settings, recommend using ExcludeSetting
+       * or ExcludeGroup instead
+       *
+       * @param setting The name of a single setting or group of settings that should not be
+       * displayed in the config panel
+       *
+       */
       void ExcludeConfig(const std::string & setting) {
-        excluded_individuals.insert(setting);
+        excluded_settings.insert(setting);
         excluded_groups.insert(setting);
       }
 
@@ -412,7 +419,7 @@ namespace prefab {
        * displayed in the config panel
        */
       void ExcludeSetting(const std::string & setting) {
-        excluded_individuals.insert(setting);
+        excluded_settings.insert(setting);
       }
 
       /**
@@ -449,7 +456,7 @@ namespace prefab {
 
           for (size_t i = 0; i < group->GetSize(); i++) {
             std::string name = group->GetEntry(i)->GetName();
-            if (Has(excluded_individuals, name)) {
+            if (Has(excluded_settings, name)) {
               continue;
             }
             std::string type = group->GetEntry(i)->GetType();

--- a/include/emp/prefab/ConfigPanel.hpp
+++ b/include/emp/prefab/ConfigPanel.hpp
@@ -455,7 +455,7 @@ namespace prefab {
             std::string type = group->GetEntry(i)->GetType();
             std::string value = group->GetEntry(i)->GetValue();
 
-            card.AddBodyContent(input_divs[name]);
+            card << input_divs[name];
 
             // Setting element label
             web::Div setting_element(name + "_row");
@@ -513,6 +513,7 @@ namespace prefab {
       /** @return Div containing the entire config panel
        *  @deprecated Can directly stream this component
        */
+      [[deprecated("Can directly stream this component into another")]]
       web::Div & GetConfigPanelDiv() { return (*this); }
 
   };

--- a/include/emp/prefab/ConfigPanel.hpp
+++ b/include/emp/prefab/ConfigPanel.hpp
@@ -107,7 +107,8 @@ namespace prefab {
 
       inline static std::set<std::string> numeric_types = {"int", "double", "float", "uint32_t", "uint64_t", "size_t"};
       Config & config;
-      std::set<std::string> exclude;
+      std::set<std::string> excluded_individuals;
+      std::set<std::string> excluded_groups;
       std::map<std::string, web::Div> group_divs;
       std::map<std::string, web::Div> input_divs;
 
@@ -399,8 +400,30 @@ namespace prefab {
         // Otherwise val is 0 and we have nothing to go on
       }
 
-      void ExcludeConfig(const std::string setting) {
-        exclude.insert(setting);
+
+      void ExcludeConfig(const std::string & setting) {
+        excluded_individuals.insert(setting);
+        excluded_groups.insert(setting);
+      }
+
+      /**
+       * Excludes a specific setting from the config panel
+       *
+       * @param setting name of the setting that should not be
+       * displayed in the config panel
+       */
+      void ExcludeSetting(const std::string & setting) {
+        excluded_individuals.insert(setting);
+      }
+
+      /**
+       * Excludes an entire group of settings from the config panel
+       *
+       * @param setting_group name of the group that should not be
+       * displayed in the config panel
+       */
+      void ExcludeGroup(const std::string & setting_group) {
+        excluded_groups.insert(setting_group);
       }
 
       /**
@@ -410,6 +433,10 @@ namespace prefab {
        */
       void Setup(const std::string & id_prefix = "settings_") {
         for (auto group : config.GetGroupSet()) {
+          std::string group_name = group->GetName()
+          if (Has(excluded_groups, group_name)) {
+            continue;
+          }
           std::string group_name = group->GetName();
           group_divs[group_name] = web::Div(id_prefix + group_name);
           (*this) << group_divs[group_name];
@@ -426,7 +453,7 @@ namespace prefab {
 
           for (size_t i = 0; i < group->GetSize(); i++) {
             std::string name = group->GetEntry(i)->GetName();
-            if (Has(exclude, name)) {
+            if (Has(excluded_individual, name)) {
               continue;
             }
             std::string type = group->GetEntry(i)->GetType();

--- a/include/emp/prefab/ConfigPanel.hpp
+++ b/include/emp/prefab/ConfigPanel.hpp
@@ -107,7 +107,6 @@ namespace prefab {
 
       inline static std::set<std::string> numeric_types = {"int", "double", "float", "uint32_t", "uint64_t", "size_t"};
       Config & config;
-      web::Div settings_div;
       std::set<std::string> exclude;
       std::map<std::string, web::Div> group_divs;
       std::map<std::string, web::Div> input_divs;
@@ -127,9 +126,9 @@ namespace prefab {
        * @param input2 ID of the second input that needs its value updated
        */
       void SyncForm(const std::string val, const std::string input1, const std::string input2) {
-          emp::web::Input div1(settings_div.Find(input1));
+          emp::web::Input div1(this->Find(input1));
           div1.Value(val);
-          emp::web::Input div2(settings_div.Find(input2));
+          emp::web::Input div2(this->Find(input2));
           div2.Value(val);
           div1.Redraw();
           div2.Redraw();
@@ -413,7 +412,7 @@ namespace prefab {
         for (auto group : config.GetGroupSet()) {
           std::string group_name = group->GetName();
           group_divs[group_name] = web::Div(id_prefix + group_name);
-          settings_div << group_divs[group_name];
+          (*this) << group_divs[group_name];
 
           // Prefab Card
           prefab::Card card("INIT_OPEN");
@@ -488,8 +487,10 @@ namespace prefab {
         settings_div << reset_button;
       }
 
-      /// @return Div containing the entire config panel
-      web::Div & GetConfigPanelDiv() { return settings_div; }
+      /** @return Div containing the entire config panel
+       * \deprecated Can directly stream this component
+       */
+      web::Div & GetConfigPanelDiv() { return (*this); }
 
   };
 }

--- a/include/emp/prefab/ConfigPanel.hpp
+++ b/include/emp/prefab/ConfigPanel.hpp
@@ -488,7 +488,7 @@ namespace prefab {
       }
 
       /** @return Div containing the entire config panel
-       * \deprecated Can directly stream this component
+       *  @deprecated Can directly stream this component
        */
       web::Div & GetConfigPanelDiv() { return (*this); }
 

--- a/include/emp/prefab/ConfigPanel.hpp
+++ b/include/emp/prefab/ConfigPanel.hpp
@@ -109,7 +109,6 @@ namespace prefab {
       Config & config;
       std::set<std::string> excluded_individuals;
       std::set<std::string> excluded_groups;
-      std::map<std::string, web::Div> group_divs;
       std::map<std::string, web::Div> input_divs;
 
       std::function<std::string(std::string val)> format_label_fun = [](std::string name) {
@@ -437,13 +436,10 @@ namespace prefab {
           if (Has(excluded_groups, group_name)) {
             continue;
           }
-    
-          group_divs[group_name] = web::Div(id_prefix + group_name);
-          (*this) << group_divs[group_name];
 
           // Prefab Card
-          prefab::Card card("INIT_OPEN");
-          group_divs[group_name] << card;
+          prefab::Card card("INIT_OPEN", true, id_prefix + group_name);
+          (*this) << card;
 
           // Header content
           web::Div setting_heading;

--- a/include/emp/prefab/ConfigPanel.hpp
+++ b/include/emp/prefab/ConfigPanel.hpp
@@ -433,11 +433,11 @@ namespace prefab {
        */
       void Setup(const std::string & id_prefix = "settings_") {
         for (auto group : config.GetGroupSet()) {
-          std::string group_name = group->GetName()
+          std::string group_name = group->GetName();
           if (Has(excluded_groups, group_name)) {
             continue;
           }
-          std::string group_name = group->GetName();
+    
           group_divs[group_name] = web::Div(id_prefix + group_name);
           (*this) << group_divs[group_name];
 
@@ -453,7 +453,7 @@ namespace prefab {
 
           for (size_t i = 0; i < group->GetSize(); i++) {
             std::string name = group->GetEntry(i)->GetName();
-            if (Has(excluded_individual, name)) {
+            if (Has(excluded_individuals, name)) {
               continue;
             }
             std::string type = group->GetEntry(i)->GetType();

--- a/include/emp/prefab/ConfigPanel.hpp
+++ b/include/emp/prefab/ConfigPanel.hpp
@@ -229,16 +229,19 @@ namespace prefab {
           [this,name, name_input_number, name_input_mobile_slider](std::string val) {
           config.Set(name, val);
           SyncForm(val, name_input_number, name_input_mobile_slider);
+          DoOnChangeFun(val);
           });
         number.Callback(
           [this,name, name_input_slider, name_input_mobile_slider](std::string val) {
           config.Set(name, val);
           SyncForm(val, name_input_slider, name_input_mobile_slider);
+          // DoOnChange will be triggered by SyncForm
           });
         mobile_slider.Callback(
           [this,name, name_input_number, name_input_slider](std::string val) {
           config.Set(name, val);
           SyncForm(val, name_input_number, name_input_slider);
+          // DoOnChange will be triggered by SyncForm
           });
         // Set initial values
         slider.Value(config.Get(name));
@@ -343,8 +346,10 @@ namespace prefab {
       ConfigPanel(
         Config & c,
         const std::string & div_name = "settings_div"
-      ) : config(c)
-      { info = new internal::ConfigPanelInfo(div_name); }
+      ) : config(c) {
+        info = new internal::ConfigPanelInfo(div_name);
+        settings_div.SetCSS("display", "flex", "flex-direction", "column");
+      }
 
       /**
        * Sets on-update callback for a ConfigPanel.
@@ -469,6 +474,18 @@ namespace prefab {
             }
           }
         }
+        web::Button reset_button{ [this](){
+          std::stringstream ss;
+          config.WriteUrlQueryString(ss);
+          const std::string tmp(ss.str());
+          const char* cstr = tmp.c_str();
+          EM_ASM({
+            window.location.href = UTF8ToString($0);
+          }, cstr);
+         }, "Reset with changes", "settings_reset"};
+        reset_button.SetAttr("class", "btn btn-danger");
+        reset_button.SetCSS("order", "1", "margin-left", "auto");
+        settings_div << reset_button;
       }
 
       /// @return Div containing the entire config panel

--- a/include/emp/tools/string_utils.hpp
+++ b/include/emp/tools/string_utils.hpp
@@ -12,20 +12,21 @@
 #ifndef EMP_STRING_UTILS_H
 #define EMP_STRING_UTILS_H
 
+#include <algorithm>
+#include <cctype>
 #include <cstdio>
 #include <functional>
 #include <initializer_list>
+#include <iomanip>
 #include <iostream>
+#include <iterator>
+#include <memory>
+#include <numeric>
+#include <regex>
 #include <sstream>
 #include <string>
 #include <string_view>
 #include <unordered_set>
-#include <algorithm>
-#include <iterator>
-#include <limits>
-#include <regex>
-#include <memory>
-#include <numeric>
 
 #include "../base/array.hpp"
 #include "../base/assert.hpp"
@@ -127,6 +128,57 @@ namespace emp {
     web_safe = std::regex_replace(web_safe, double_quote, "&quot");
 
     return web_safe;
+  }
+
+
+  /// Returns url encoding of value.
+  /// See https://en.wikipedia.org/wiki/Percent-encoding
+  // adapted from https://stackoverflow.com/a/17708801
+  template<bool encode_space=false>
+  std::string url_encode(const std::string &value) {
+    std::ostringstream escaped;
+    escaped.fill('0');
+    escaped << std::hex;
+
+    for (const auto c : value) {
+
+      // If encoding space, replace with +
+      if ( encode_space && c == ' ' ) escaped << '+';
+      // Keep alphanumeric and other accepted characters intact
+      else if (
+        std::isalnum(c) || c == '-' || c == '_' || c == '.' || c == '~'
+      ) escaped << c;
+      // Any other characters are percent-encoded
+      else {
+        escaped << std::uppercase;
+        escaped << '%' << std::setw(2) << (static_cast<int>(c) & 0x000000FF);
+        escaped << std::nouppercase;
+      }
+
+    }
+
+    return escaped.str();
+  }
+
+  /// Returns url decoding of string.
+  /// See https://en.wikipedia.org/wiki/Percent-encoding
+  // adapted from https://stackoverflow.com/a/29962178
+  template<bool decode_plus=false>
+  std::string url_decode(const std::string& str){
+    std::string res;
+
+    for (size_t i{}; i < str.size(); ++i) {
+      if (str[i] == '%') {
+        int hex_code;
+        std::sscanf(str.substr(i + 1, 2).c_str(), "%x", &hex_code);
+        res += static_cast<char>(hex_code);
+        i += 2;
+      } else {
+        res += ( decode_plus && str[i] == '+' ) ? ' ' : str[i];
+      }
+    }
+
+    return res;
   }
 
   /// Take a value and convert it to a C++-style literal.
@@ -576,7 +628,7 @@ namespace emp {
   inline bool has_prefix(const std::string & in_string, const std::string & prefix) {
     if (prefix.size() > in_string.size()) return false;
     for (size_t i = 0; i < prefix.size(); ++i) {
-      if (in_string[i] != prefix[i]) return false;      
+      if (in_string[i] != prefix[i]) return false;
     }
     return true;
   }

--- a/include/emp/web/UrlParams.hpp
+++ b/include/emp/web/UrlParams.hpp
@@ -19,25 +19,44 @@
 
 namespace emp {
 namespace web {
-
+  /**
+   * Extracts the query portion of a url and parses for key value pairs.
+   *
+   * @note In a query space encoded by "%20" is interpreted as a space character
+   * while the space encoded by "+" is used to separate a list of values for a key.
+   * For example querying "?seed=100&strings=hi%20there+blah" will be parsed
+   * to the parameter array [["seed", "100"], ["strings", "hi there", "blah"]]
+   * then converted to a multimap.
+   *
+   * Some esoterica: "?string=this+that" and "?string=this&string=that"
+   * have different meanings and may result in different behavior.
+   * Similarly "?test" becomes [["test"]] while "?test=" becomes
+   * [["test", ""]].
+   */
   std::multimap<std::string, emp::vector<std::string>> GetUrlParams() {
 
     emp::vector<emp::vector<std::string>> incoming;
 
     MAIN_THREAD_EM_ASM({
-      const params = new URLSearchParams(location.search);
-      emp_i.__outgoing_array = Array.from(
-        params.entries()
-      ).map(
-        p => p[0].replace(" ", "").length == 0
-          ?  ["_illegal", "_empty" + " " + p[1]] : p
-      ).map(
-        p => p[0].includes(" ") ? ["_illegal", p[0] + " " + p[1]] : p
-      ).map(
-        p => [p[0]].concat(p[1].split(" "))
-      ).map(
-        p => p.filter(w => w.length > 0)
-      );
+      emp_i.__outgoing_array = location.search.includes('?')
+      ? location.search.substring(1).split('&'
+        ).map(
+          expr => expr.split("=")
+        ).map(
+          (list) => [list[0].split("+").join(" ")].concat(
+            list[1] && list[1].split('+')
+          ).filter(
+            item => item !== undefined
+          )
+        ).map(
+          list => list.map(decodeURIComponent)
+        ).map(
+          p => p[0].split(" ").join("").length == 0
+            ?  ["_illegal", "_empty=" + p[1]] : p
+        ).map(
+          p => p[0].includes(" ") ? ["_illegal", p[0] + "=" + p[1]] : p
+        )
+      : [];
     });
 
     emp::pass_vector_to_cpp(incoming);

--- a/tests/config/assets/config_setup.hpp
+++ b/tests/config/assets/config_setup.hpp
@@ -34,6 +34,7 @@ EMP_BUILD_CONFIG( MyConfig,
   VALUE(TEST_STRING, std::string, "default", "This is a string!"),
   CONST(TEST_CONST, int, 91, "This is an unchanging const!"),
   VALUE(TEST_STRING_SPACE, std::string, "abc def   ghi", "This is a string with spaces."),
+  VALUE(TEST_STRING_QUOTE, std::string, "\"Quote\"andonemore\"soit'sodd", "This is a string with quote marks."),
   //VALUE(MUTATION_RATE, float, 0.025, "This is my mutation rate.", MUT_RATE),
   VALUE(MUTATION_RATE, float, 0.025, "This is my mutation rate."),
 )

--- a/tests/config/config.cpp
+++ b/tests/config/config.cpp
@@ -34,6 +34,21 @@ TEST_CASE("Test config", "[config]"){
     std::cout << "Random seed = " << config.RANDOM_SEED() << std::endl;
 
     REQUIRE(config.RANDOM_SEED() == 123);
+    REQUIRE(config.TEST_STRING_SPACE() == "abc def   ghi");
+    REQUIRE(config.TEST_STRING_QUOTE() == "\"Quote\"andonemore\"soit'sodd");
+
+    std::stringstream query_stream;
+    config.WriteUrlQueryString(query_stream);
+    std::string query(query_stream.str());
+    std::cout << query << std::endl;
+    REQUIRE(query[0] == '?');
+    REQUIRE(query.find("DEBUG_MODE=0") != std::string::npos);
+    REQUIRE(query.find("RANDOM_SEED=123") != std::string::npos);
+    REQUIRE(query.find("&TEST_BOOL=0") != std::string::npos);
+    REQUIRE(query.find("TEST_CONST=91") != std::string::npos);
+    REQUIRE(query.find("TEST_STRING_SPACE=abc%20def%20%20%20ghi") != std::string::npos);
+    REQUIRE(query.find("TEST_STRING_QUOTE=%22Quote%22andonemore%22soit%27sodd") != std::string::npos);
+    REQUIRE(query.find("MUTATION_RATE=0.025") != std::string::npos);
 
   }
 

--- a/tests/tools/string_utils.cpp
+++ b/tests/tools/string_utils.cpp
@@ -487,3 +487,12 @@ TEST_CASE("Test repeat", "[tools]") {
 	REQUIRE( emp::repeat("abc", 2) == "abcabc" );
 
 }
+
+TEST_CASE("Test url-encode", "[tools]") {
+  REQUIRE( emp::url_encode("шеллы") == "%D1%88%D0%B5%D0%BB%D0%BB%D1%8B" );
+  REQUIRE( emp::url_decode("%D1%88%D0%B5%D0%BB%D0%BB%D1%8B") == "шеллы" );
+  REQUIRE( emp::url_encode(" ") == "%20" );
+  REQUIRE( emp::url_encode<true>(" ") == "+" );
+  REQUIRE( emp::url_decode("%20+") == " +" );
+  REQUIRE( emp::url_decode<true>("%20+") == "  " );
+}

--- a/tests/web/Card.cpp
+++ b/tests/web/Card.cpp
@@ -28,8 +28,9 @@ struct Test_Card_STATIC_HTMLLayout : public emp::web::BaseTest {
    *
    *  <div id="static_card_body" class="card-body">
    *    <div id="div_body">
-   *      <span id="emp__1">body content</span>
+   *      <span id="emp__1">body content 1</span>
    *    </div>
+   *    <span id="emp__1">body content 2</span>
    *  </div>
    *
    * </div>
@@ -45,8 +46,8 @@ struct Test_Card_STATIC_HTMLLayout : public emp::web::BaseTest {
     static_card.AddHeaderContent("Static Card Title");
     emp::web::Div body("div_body");
     static_card.AddBodyContent(body);
-    body << "body content";
-
+    body << "body content 1";
+    static_card << "body content 2";
   }
 
   void Describe() override {
@@ -141,8 +142,8 @@ struct Test_Card_STATIC_HTMLLayout : public emp::web::BaseTest {
             chai.assert.isTrue(document.getElementById('static_card_body').classList.contains('card-body'));
           });
 
-          it('should have one child', function() {
-            chai.assert.equal($("#static_card_body").children().length, 1);
+          it('should have two children', function() {
+            chai.assert.equal($("#static_card_body").children().length, 2);
           });
 
           it('should have child div#div_body', function() {
@@ -167,6 +168,10 @@ struct Test_Card_STATIC_HTMLLayout : public emp::web::BaseTest {
             it('should have child of type span', function() {
               chai.assert.equal(child.children[0].nodeName, "SPAN");
             });
+          });
+
+          it('should have a child of type span', function() {
+            chai.assert.equal($("#static_card_body").children()[1].nodeName, "SPAN");
           });
         });
       });
@@ -196,6 +201,7 @@ struct Test_Card_INIT_OPEN_HTMLLayout : public emp::web::BaseTest {
    *  <div id="open_card_body" class="card-body , collapse show , open_card_collapse">
    *    <span id="emp__5">
    *      <p>collapsible card body</p>
+   *      <p>alternatively inserted text</p>
    *    </span>
    *  </div>
    *
@@ -212,6 +218,7 @@ struct Test_Card_INIT_OPEN_HTMLLayout : public emp::web::BaseTest {
     emp::web::Div header("div_header");
     open_card.AddHeaderContent(header);
     open_card.AddBodyContent("<p>collapsible card body</p>");
+    open_card << "<p>alternatively insterted text</p>";
     header << "<h3>init open title</h3>";
 
   }
@@ -448,20 +455,30 @@ struct Test_Card_INIT_OPEN_HTMLLayout : public emp::web::BaseTest {
               chai.assert.equal(child.nodeName, "SPAN");
             });
 
-            it('should have one child', function() {
-              chai.assert.equal(child.childElementCount, 1);
+            it('should have two children', function() {
+              chai.assert.equal(child.childElementCount, 2);
             });
           });
 
           describe("Grandchild", function() {
-            const grandchild = $("#open_card_body").children()[0].children[0];
+            const grandchild1 = $("#open_card_body").children()[0].children[0];
 
             it('should be a p element', function() {
-              chai.assert.equal(grandchild.nodeName, "P");
+              chai.assert.equal(grandchild1.nodeName, "P");
             });
 
             it('should have no children', function() {
-              chai.assert.equal(grandchild.childElementCount, 0);
+              chai.assert.equal(grandchild1.childElementCount, 0);
+            });
+
+            const grandchild2 = $("#open_card_body").children()[0].children[1];
+
+            it('should be a p element', function() {
+              chai.assert.equal(grandchild2.nodeName, "P");
+            });
+
+            it('should have no children', function() {
+              chai.assert.equal(grandchild2.childElementCount, 0);
             });
           });
         });

--- a/tests/web/ConfigPanel.cpp
+++ b/tests/web/ConfigPanel.cpp
@@ -27,7 +27,7 @@ struct Test_Config_Panel_HTMLLayout : public emp::web::BaseTest {
    * Construct the following HTML structure:
    *
    * <div id="emp_base">
-   *  <div id="emp__1">
+   *  <div id="settings">
    *    <div id="settings_MAIN">
    *      <div id="emp__3" class="card">
    *        <div id="emp__3_card_header" aria-controls=".emp__3_card_collapse" aria-expanded="true" class="card-header , collapse_toggle , collapse_toggle_card_header" data-target=".emp__3_card_collapse" data-toggle="collapse" role="button">
@@ -135,6 +135,7 @@ struct Test_Config_Panel_HTMLLayout : public emp::web::BaseTest {
    *
    *    <div id="emp__56"><div id="ASYMMETRIC_DIVISION_PROB_row" class="setting_element">
    *      ....
+   *    <button> Reset with changes </button>
    * </div>
    */
 
@@ -152,7 +153,7 @@ struct Test_Config_Panel_HTMLLayout : public emp::web::BaseTest {
 
     // setup configuration panel
     config_panel.Setup();
-    Doc("emp_test_container") << config_panel.GetConfigPanelDiv();
+    Doc("emp_test_container") << config_panel;
     emp::prefab::CloseLoadingModal();
 
   }
@@ -173,8 +174,8 @@ struct Test_Config_Panel_HTMLLayout : public emp::web::BaseTest {
           });
         });
 
-        // user doesn't define config panel ID, find object here
-        const config_panel = document.getElementById('emp_test_container').children[0];
+        // Default config panel has id 'settings_div'
+        const config_panel = document.getElementById('settings_div');
 
         describe("ConfigPanel (div#emp_test_container Child)", function() {
           it('should exist', function() {
@@ -207,182 +208,161 @@ struct Test_Config_Panel_HTMLLayout : public emp::web::BaseTest {
         });
 
         describe("#settings_MAIN", function() {
-          const main =  document.getElementById("settings_MAIN");
+          const main_card =  document.getElementById("settings_MAIN");
           it('should have parent ConfigPanel', function() {
-            const parent_id = main.parentElement.id;
+            const parent_id = main_card.parentElement.id;
             chai.assert.equal(parent_id, config_panel.id);
           });
 
-          it('should have 1 child ', function() {
-            chai.assert.equal(main.childElementCount, 1);
+          it('should have class card', function() {
+            chai.assert.isTrue(main_card.classList.contains("card"));
           });
 
-          const card = main.children[0];
-          describe("Basic card layout", function() {
-            it('should have class card', function() {
-              chai.assert.isTrue(card.classList.contains("card"));
+          it('should have 2 child (card header and body)', function() {
+            chai.assert.equal(main_card.childElementCount, 2);
+          });
+
+          it('should have card header child', function() {
+            chai.assert.isTrue(main_card.children[0].classList.contains("card-header"));
+          });
+
+          it('should have card body child', function() {
+            chai.assert.isTrue(main_card.children[1].classList.contains("card-body"));
+          });
+
+          // Note: Not checking card toggle functionality here because
+          // it is tested in Card.cc mocha tests
+
+          describe("Card Header", function() {
+            const card_header = main_card.children[0];
+            it('should have 3 children', function() {
+              chai.assert.equal(card_header.childElementCount, 3);
             });
 
-            it('should have 2 children', function() {
-              chai.assert.equal(card.childElementCount, 2);
+            it('should have an arrow up glyph', function() {
+              chai.assert.isTrue(card_header.children[0].classList.contains("fa-angle-double-up"));
             });
 
-            it('should have card header child', function() {
-              chai.assert.isTrue(card.children[0].classList.contains("card-header"));
+            it('should have an arrow down glyph', function() {
+              chai.assert.isTrue(card_header.children[1].classList.contains("fa-angle-double-down"));
             });
 
-            it('should have card body child', function() {
-              chai.assert.isTrue(card.children[1].classList.contains("card-body"));
+            it('should have a title with class setting_heading', function() {
+              chai.assert.isTrue(card_header.children[2].classList.contains("setting_heading"));
             });
+          });
 
-            // Note: Not checking card toggle functionality here because
-            // it is tested in Card.cc mocha tests
-
-            describe("Card Header", function() {
-              const card_header = card.children[0];
-              it('should have 3 children', function() {
-                chai.assert.equal(card_header.childElementCount, 3);
-              });
-
-              it('should have an arrow up glyph', function() {
-                chai.assert.isTrue(card_header.children[0].classList.contains("fa-angle-double-up"));
-              });
-
-              it('should have an arrow down glyph', function() {
-                chai.assert.isTrue(card_header.children[1].classList.contains("fa-angle-double-down"));
-              });
-
-              it('should have a title with class setting_heading', function() {
-                chai.assert.isTrue(card_header.children[2].classList.contains("setting_heading"));
-              });
-            });
-
-            describe("Card Body", function() {
-              const card_body = card.children[1];
-              it('should have 3 settings', function() {
-                chai.assert.equal(card_body.childElementCount, 3);
-              });
+          describe("Card Body", function() {
+            const card_body = main_card.children[1];
+            it('should have 3 settings', function() {
+              chai.assert.equal(card_body.childElementCount, 3);
             });
           });
         });
 
         describe("#setting_CELL", function() {
-          const cell  =  document.getElementById("settings_CELL");
+          const cell_card  =  document.getElementById("settings_CELL");
           it('should have parent Config Panel div', function() {
-            chai.assert.equal(cell.parentElement.id, config_panel.id);
+            chai.assert.equal(cell_card.parentElement.id, config_panel.id);
           });
 
-          it('should have 1 child', function() {
-            chai.assert.equal(cell.childElementCount, 1);
+          it('should have card class', function() {
+              chai.assert.isTrue(cell_card.classList.contains("card"));
           });
 
-          const card = cell.children[0];
-          describe("Basic card layout", function() {
-            it('should have card class', function() {
-              chai.assert.isTrue(card.classList.contains("card"));
+          it('should have 2 children', function() {
+            chai.assert.equal(cell_card.childElementCount, 2);
+          });
+
+          it('should have card header child', function() {
+            chai.assert.isTrue(cell_card.children[0].classList.contains("card-header"));
+          });
+
+          it('should have card body child', function() {
+            chai.assert.isTrue(cell_card.children[1].classList.contains("card-body"));
+          });
+
+          // Note: Not checking card toggle functionality here because
+          // it is tested in Card.cc mocha tests
+
+          describe("Card Header", function() {
+            const card_header = cell_card.children[0];
+            it('should have 3 children', function() {
+              chai.assert.equal(card_header.childElementCount, 3);
             });
 
-            it('should have 2 children', function() {
-              chai.assert.equal(card.childElementCount, 2);
+            it('should have an arrow up glyph', function() {
+              chai.assert.isTrue(card_header.children[0].classList.contains("fa-angle-double-up"));
             });
 
-            it('should have card header child', function() {
-              chai.assert.isTrue(card.children[0].classList.contains("card-header"));
+            it('should have an arrow down glyph', function() {
+              chai.assert.isTrue(card_header.children[1].classList.contains("fa-angle-double-down"));
             });
 
-            it('should have card body child', function() {
-              chai.assert.isTrue(card.children[1].classList.contains("card-body"));
-            });
-
-            // Note: Not checking card toggle functionality here because
-            // it is tested in Card.cc mocha tests
-
-            describe("Card Header", function() {
-              const card_header = card.children[0];
-              it('should have 3 children', function() {
-                chai.assert.equal(card_header.childElementCount, 3);
-              });
-
-              it('should have an arrow up glyph', function() {
-                chai.assert.isTrue(card_header.children[0].classList.contains("fa-angle-double-up"));
-              });
-
-              it('should have an arrow down glyph', function() {
-                chai.assert.isTrue(card_header.children[1].classList.contains("fa-angle-double-down"));
-              });
-
-              it('should have a title with class setting_heading', function() {
-                chai.assert.isTrue(card_header.children[2].classList.contains("setting_heading"));
-              });
-            });
-
-            describe("Card Body", function() {
-              const card_body = card.children[1];
-              it('should have 2 settings', function() {
-                chai.assert.equal(card_body.childElementCount, 2);
-              });
+            it('should have a title with class setting_heading', function() {
+              chai.assert.isTrue(card_header.children[2].classList.contains("setting_heading"));
             });
           });
 
+          describe("Card Body", function() {
+            const card_body = cell_card.children[1];
+            it('should have 2 settings', function() {
+              chai.assert.equal(card_body.childElementCount, 2);
+            });
+          });
         });
 
         describe("#setting_TREATMENT", function() {
-          const treatment = document.getElementById("settings_TREATMENT");
+          const treatment_card = document.getElementById("settings_TREATMENT");
           it('should have parent Config Panel div', function() {
-            chai.assert.equal(treatment.parentElement.id, config_panel.id);
+            chai.assert.equal(treatment_card.parentElement.id, config_panel.id);
           });
 
-          it('should have 1 child', function() {
-            chai.assert.equal(treatment.childElementCount, 1);
+          it('should have card class', function() {
+            chai.assert.isTrue(treatment_card.classList.contains("card"));
           });
 
-          const card = treatment.children[0];
-          describe("Basic card layout", function() {
-            it('should have card class', function() {
-              chai.assert.isTrue(card.classList.contains("card"));
+          it('should have 2 children', function() {
+            chai.assert.equal(treatment_card.childElementCount, 2);
+          });
+
+          it('should have card header child', function() {
+            chai.assert.isTrue(treatment_card.children[0].classList.contains("card-header"));
+          });
+
+          it('should have card body child', function() {
+            chai.assert.isTrue(treatment_card.children[1].classList.contains("card-body"));
+          });
+
+          // Note: Not checking card toggle functionality here because
+          // it is tested in Card.cc mocha tests
+
+          describe("Card Header", function() {
+            const card_header = treatment_card.children[0];
+            it('should have 3 children', function() {
+              chai.assert.equal(card_header.childElementCount, 3);
             });
 
-            it('should have 2 children', function() {
-              chai.assert.equal(card.childElementCount, 2);
+            it('should have an arrow up glyph', function() {
+              chai.assert.isTrue(card_header.children[0].classList.contains("fa-angle-double-up"));
             });
 
-            it('should have card header child', function() {
-              chai.assert.isTrue(card.children[0].classList.contains("card-header"));
+            it('should have an arrow down glyph', function() {
+              chai.assert.isTrue(card_header.children[1].classList.contains("fa-angle-double-down"));
             });
 
-            it('should have card body child', function() {
-              chai.assert.isTrue(card.children[1].classList.contains("card-body"));
-            });
-
-            // Note: Not checking card toggle functionality here because
-            // it is tested in Card.cc mocha tests
-
-            describe("Card Header", function() {
-              const card_header = card.children[0];
-              it('should have 3 children', function() {
-                chai.assert.equal(card_header.childElementCount, 3);
-              });
-
-              it('should have an arrow up glyph', function() {
-                chai.assert.isTrue(card_header.children[0].classList.contains("fa-angle-double-up"));
-              });
-
-              it('should have an arrow down glyph', function() {
-                chai.assert.isTrue(card_header.children[1].classList.contains("fa-angle-double-down"));
-              });
-
-              it('should have a title with class setting_heading', function() {
-                chai.assert.isTrue(card_header.children[2].classList.contains("setting_heading"));
-              });
-            });
-
-            describe("Card Body", function() {
-              const card_body = card.children[1];
-              it('should have 2 settings', function() {
-                chai.assert.equal(card_body.childElementCount, 2);
-              });
+            it('should have a title with class setting_heading', function() {
+              chai.assert.isTrue(card_header.children[2].classList.contains("setting_heading"));
             });
           });
+
+          describe("Card Body", function() {
+            const card_body = treatment_card.children[1];
+            it('should have 2 settings', function() {
+              chai.assert.equal(card_body.childElementCount, 2);
+            });
+          });
+
         });
       });
     });
@@ -435,7 +415,7 @@ struct Test_Config_Panel_Int_HTMLLayout : public emp::web::BaseTest {
 
     // setup configuration panel
     config_panel.Setup();
-    Doc("emp_test_container") << config_panel.GetConfigPanelDiv();
+    Doc("emp_test_container") << config_panel;
     emp::prefab::CloseLoadingModal();
   }
 
@@ -445,7 +425,7 @@ struct Test_Config_Panel_Int_HTMLLayout : public emp::web::BaseTest {
       describe("emp::prefab::ConfigPanel Integer Setting", function() {
         // Must use "children chain" because we rely on emscripten to generate
         // IDs for setting elements.
-        const setting = document.getElementById("settings_MAIN").children[0].children[1].children[1];
+        const setting = document.getElementById("settings_MAIN").children[1].children[1];
         it('should have 2 children', function() {
           chai.assert.equal(setting.childElementCount, 2);
         });
@@ -618,7 +598,7 @@ struct Test_Config_Panel_Double_HTMLLayout : public emp::web::BaseTest {
 
     // setup configuration panel
     config_panel.Setup();
-    Doc("emp_test_container") << config_panel.GetConfigPanelDiv();
+    Doc("emp_test_container") << config_panel;
     emp::prefab::CloseLoadingModal();
   }
 
@@ -626,7 +606,7 @@ struct Test_Config_Panel_Double_HTMLLayout : public emp::web::BaseTest {
 
     EM_ASM({
       describe("Double Setting", function() {
-      const setting = document.getElementById("settings_CELL").children[0].children[1].children[0];
+      const setting = document.getElementById("settings_CELL").children[1].children[0];
       it('should have 2 children', function() {
         chai.assert.equal(setting.childElementCount, 2);
       });
@@ -793,7 +773,7 @@ struct Test_Config_Panel_Text_HTMLLayout : public emp::web::BaseTest {
 
     // setup configuration panel
     config_panel.Setup();
-    Doc("emp_test_container") << config_panel.GetConfigPanelDiv();
+    Doc("emp_test_container") << config_panel;
     emp::prefab::CloseLoadingModal();
   }
 
@@ -801,7 +781,7 @@ struct Test_Config_Panel_Text_HTMLLayout : public emp::web::BaseTest {
 
     EM_ASM({
       describe("Text Setting", function() {
-      const setting = document.getElementById("settings_MAIN").children[0].children[1].children[2];
+      const setting = document.getElementById("settings_MAIN").children[1].children[2];
       it('should have 2 children', function() {
         chai.assert.equal(setting.childElementCount, 2);
       });
@@ -927,7 +907,7 @@ struct Test_Config_Panel_Bool_HTMLLayout : public emp::web::BaseTest {
 
     // setup configuration panel
     config_panel.Setup();
-    Doc("emp_test_container") << config_panel.GetConfigPanelDiv();
+    Doc("emp_test_container") << config_panel;
     emp::prefab::CloseLoadingModal();
   }
 
@@ -935,7 +915,7 @@ struct Test_Config_Panel_Bool_HTMLLayout : public emp::web::BaseTest {
 
     EM_ASM({
       describe("Boolean setting", function() {
-        const setting = document.getElementById("settings_MAIN").children[0].children[1].children[0];
+        const setting = document.getElementById("settings_MAIN").children[1].children[0];
         it('should have 2 children', function() {
           chai.assert.equal(setting.childElementCount, 2);
         });

--- a/tests/web/ConfigPanel.cpp
+++ b/tests/web/ConfigPanel.cpp
@@ -186,8 +186,8 @@ struct Test_Config_Panel_HTMLLayout : public emp::web::BaseTest {
             chai.assert.equal(parent_id, "emp_test_container");
           });
 
-          it('should have 3 children', function() {
-            chai.assert.equal(config_panel.childElementCount, 3);
+          it('should have 4 children (3 groups, 1 reset button)', function() {
+            chai.assert.equal(config_panel.childElementCount, 4);
           });
 
           it('should have child #settings_MAIN', function() {
@@ -200,6 +200,9 @@ struct Test_Config_Panel_HTMLLayout : public emp::web::BaseTest {
 
           it('should have child #settings_TREATMENT', function() {
             chai.assert.equal(config_panel.children[2].id, "settings_TREATMENT");
+          });
+          it('should have child #settings_reset', function() {
+            chai.assert.equal(config_panel.children[3].id, "settings_reset");
           });
         });
 

--- a/tests/web/ConfigPanel.cpp
+++ b/tests/web/ConfigPanel.cpp
@@ -1001,6 +1001,52 @@ struct Test_Config_Panel_Bool_HTMLLayout : public emp::web::BaseTest {
   }
 };
 
+struct Test_Config_Panel_Exclusion_HTMLLayout : public emp::web::BaseTest {
+
+  emp::prefab::ConfigPanel config_panel{cfg};
+
+  Test_Config_Panel_Exclusion_HTMLLayout()
+  : BaseTest({"emp_test_container"}) // we can tell BaseTest that we want to create a set of emp::web::Document
+                                     // objects for each given html element ids.
+  {
+    // apply configuration query params and config files to Config
+    auto specs = emp::ArgManager::make_builtin_specs(&cfg);
+    emp::ArgManager am(emp::web::GetUrlParams(), specs);
+    // cfg.Read("config.cfg");
+    am.UseCallbacks();
+    if (am.HasUnused()) std::exit(EXIT_FAILURE);
+
+    // setup configuration panel
+    config_panel.Setup();
+    config_panel.ExcludeConfig("SEED");
+    config_panel.ExcludeSetting("RADIATION_PRESCRIPTION_FILE");
+    config_panel.ExcludeGroup("TREATMENT");
+
+    Doc("emp_test_container") << config_panel;
+    emp::prefab::CloseLoadingModal();
+  }
+
+  void Describe() override {
+    EM_ASM({
+      describe('Excluded settings and groups', function() {
+        const config_panel = document.getElementById('settings_div');
+        it('should have only 3 children (only 2 groups now, 1 reset button)', function() {
+          chai.assert(config_panel.childElementCount, 3);
+        });
+
+        describe('MAIN group', function() {
+          const main_card_body = document.getElementById("settings_MAIN").children[1];
+          it('should have only 1 child (2 excluded)', function() {
+            chai.assert(main_card_body.childElementCount, 1);
+          });
+        });
+      });
+    });
+  }
+};
+
+
+
 emp::web::MochaTestRunner test_runner;
 
 int main() {
@@ -1011,6 +1057,7 @@ int main() {
   test_runner.AddTest<Test_Config_Panel_Double_HTMLLayout>("Test ConfigPanel Double Input HTML Layout");
   test_runner.AddTest<Test_Config_Panel_Text_HTMLLayout>("Test ConfigPanel Text Input HTML Layout");
   test_runner.AddTest<Test_Config_Panel_Bool_HTMLLayout>("Test ConfigPanel Boolean Input HTML Layout");
+  test_runner.AddTest<Test_Config_Panel_Exclusion_HTMLLayout>("Test ConfigPanel Boolean Exclusion HTML Layout");
 
   test_runner.Run();
 }

--- a/tests/web/GetUrlParams.cpp
+++ b/tests/web/GetUrlParams.cpp
@@ -49,7 +49,9 @@ int main() {
 
   am.PrintDiagnostic();
 
-
+ // TODO: rewrite this to use catch/REQUIRE
+ // (since this breaks without rhyme or reason and just crashes to indicate
+ //  a failed test rather than failing gracefully for some checks)
   emp_assert(*am.UseArg("test1") == emp::vector<std::string>({"val1"}));
   emp_assert(*am.UseArg("test1") == emp::vector<std::string>({"val2","val3"}));
   emp_assert(!am.UseArg("test1"));

--- a/tests/web/GetUrlParams.cpp
+++ b/tests/web/GetUrlParams.cpp
@@ -21,22 +21,27 @@ int main() {
   EM_ASM({
     global.location = Object();
     global.location.search = (
-      "test1=val1" +
+      "?test1=val1" +
       "&test4" +
-      "&test2=++val1" +
+      "&test5=" +
+      "&test2=val1+" +
       "&test3=1+23" +
       "&=bad" +
       "&=" +
       "&+=" +
+      "&+%20=" +
       "&=+" +
       "&+=+" +
       "&test1=val2+val3" +
       "&_positional=p1++p2" +
       "&_positional=p3+" +
       "&bad+bad=illegal" +
-      "&bad++bad=illegal" +
+      "&bad+%20bad=illegal" +
       "&+bad=illegal" +
-      "&bad+=illegal"
+      "&bad+=illegal" +
+      "&string1=no%20break" +
+      "&string2=breaks%20here+and+there" +
+      "&string3=sneakyspace%20+more"
     );
   });
 
@@ -44,53 +49,68 @@ int main() {
 
   am.PrintDiagnostic();
 
+
   emp_assert(*am.UseArg("test1") == emp::vector<std::string>({"val1"}));
   emp_assert(*am.UseArg("test1") == emp::vector<std::string>({"val2","val3"}));
   emp_assert(!am.UseArg("test1"));
 
-  emp_assert(*am.UseArg("test2") == emp::vector<std::string>({"val1"}));
+  emp_assert(*am.UseArg("test2") == emp::vector<std::string>({"val1", ""}));
   emp_assert(!am.UseArg("test2"));
 
-  emp_assert(am.UseArg("test3") == emp::vector<std::string>({"1","23"}));
+  emp_assert(*am.UseArg("test3") == emp::vector<std::string>({"1","23"}));
   emp_assert(!am.UseArg("test3"));
 
   emp_assert(*am.UseArg("test4") == emp::vector<std::string>());
   emp_assert(!am.UseArg("test4"));
 
+  emp_assert(*am.UseArg("test5") == emp::vector<std::string>({""}));
+  emp_assert(!am.UseArg("test5"));
+
   emp_assert(
-    *am.UseArg("_positional") == emp::vector<std::string>({"p1","p2","p3"})
+    *am.UseArg("_positional") == emp::vector<std::string>({"p1","","p2","p3",""})
   );
   emp_assert(!am.UseArg("_positional"));
 
   emp_assert(
-    *am.UseArg("_illegal") == emp::vector<std::string>({"_empty", "bad"})
+    *am.UseArg("_illegal") == emp::vector<std::string>({"_empty=bad"})
   );
   emp_assert(
-    *am.UseArg("_illegal") == emp::vector<std::string>({"_empty"})
+    *am.UseArg("_illegal") == emp::vector<std::string>({"_empty="})
   );
   emp_assert(
-    *am.UseArg("_illegal") == emp::vector<std::string>({"_empty"})
+    *am.UseArg("_illegal") == emp::vector<std::string>({"_empty="})
   );
   emp_assert(
-    *am.UseArg("_illegal") == emp::vector<std::string>({"_empty"})
+    *am.UseArg("_illegal") == emp::vector<std::string>({"_empty="})
   );
   emp_assert(
-    *am.UseArg("_illegal") == emp::vector<std::string>({"_empty"})
+    *am.UseArg("_illegal") == emp::vector<std::string>({"_empty="})
   );
   emp_assert(
-    *am.UseArg("_illegal") == emp::vector<std::string>({"bad","bad","illegal"})
+    *am.UseArg("_illegal") == emp::vector<std::string>({"_empty="})
   );
   emp_assert(
-    *am.UseArg("_illegal") == emp::vector<std::string>({"bad","bad","illegal"})
+    *am.UseArg("_illegal") == emp::vector<std::string>({"bad bad=illegal"})
   );
   emp_assert(
-    *am.UseArg("_illegal") == emp::vector<std::string>({"bad","illegal"})
+    *am.UseArg("_illegal") == emp::vector<std::string>({"bad  bad=illegal"})
   );
   emp_assert(
-    *am.UseArg("_illegal") == emp::vector<std::string>({"bad","illegal"})
+    *am.UseArg("_illegal") == emp::vector<std::string>({" bad=illegal"})
   );
-  emp_assert(!am.UseArg("_illegal"));
+  emp_assert(
+    *am.UseArg("_illegal") == emp::vector<std::string>({"bad =illegal"})
+  );
+  emp_assert(*am.UseArg("string1") == emp::vector<std::string>({"no break"}));
+  emp_assert(!am.UseArg("string1"));
 
-  std::cout << "Success!" << std::endl;
+  std::cout << __FILE__ << ":" << __LINE__ << std::endl;
+  emp_assert(*am.UseArg("string2") == emp::vector<std::string>({"breaks here", "and", "there"}));
+
+  emp_assert(!am.UseArg("string2"));
+
+  emp_assert(*am.UseArg("string3") == emp::vector<std::string>({"sneakyspace ", "more"}));
+
+  emp_assert(!am.UseArg("string3"));
 
 }


### PR DESCRIPTION
Allows users to directly stream a `ConfigPanel` into another component (and start working towards solving #428).
Changes default behavior of the stream operator for `Card` to placing components in the card body (closes #345).
Allow users to exclude entire groups from `ConfigPanel` (closes #427).
