### PR TITLE
Fix boolean toString mismatch

### DIFF
--- a/include/emp/web/Input.hpp
+++ b/include/emp/web/Input.hpp
@@ -259,7 +259,7 @@ namespace web {
       Info()->callback = in_cb;
       InputInfo * b_info = Info();
       Info()->callback_id = JSWrap( std::function<void(std::string)>( [b_info](std::string new_val){b_info->DoChange(new_val);} )  );
-      Info()->onchange_info = emp::to_string("emp.Callback(", Info()->callback_id, ", ['checkbox', 'radio'].includes(this.type) ? this.checked.toString() : this.value);");
+      Info()->onchange_info = emp::to_string("emp.Callback(", Info()->callback_id, ", ['checkbox', 'radio'].includes(this.type) ? (this.checked ? '1' : '0') : this.value);");
       // Allows user to set the checkbox to start out on/checked
       if (in_type.compare("checkbox") == 0 && is_checked){
         this->SetAttr("checked", "true");


### PR DESCRIPTION
In C++ the default method of printing/reading a boolean is as 1 or 0 so that's what was happening in `config.h` and string util's `emp::to_string`. However, `Input` used Javascript's `toString` to pass the checked value from an input tag which uses "true" and "false". This mismatch prevented boolean values from being saved properly when using the config panel.