### PR TITLE
Add std::vector include to array.hpp

### DIFF
--- a/include/emp/base/array.hpp
+++ b/include/emp/base/array.hpp
@@ -21,6 +21,7 @@
 
 #include <initializer_list>
 #include <array>
+#include <vector>
 
 #include "assert.hpp"
 


### PR DESCRIPTION
Without this, a file that includes emp/base/array.hpp but not std::vector will fail to compile in debug mode.