### PR TITLE
Try bumping node version to 14.17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -166,7 +166,7 @@ RUN \
   && \
   npm install -g n \
   && \
-  n 12.18.2 \
+  n 14.17 \
   && \
   export python="/usr/bin/python3" \
   && \


### PR DESCRIPTION
Might fix error in GH actions build

```
> yarn@1.22.15 preinstall /usr/local/lib/node_modules/yarn
> :; (node ./preinstall.js > /dev/null 2>&1 || true)

/usr/local/bin/yarn -> /usr/local/lib/node_modules/yarn/bin/yarn.js
/usr/local/bin/yarnpkg -> /usr/local/lib/node_modules/yarn/bin/yarn.js
+ yarn@1.22.15
added 1 package in 0.603s
Cloning into 'karma-firefox-launcher'...
yarn install v1.22.15
[1/4] Resolving packages...
[2/4] Fetching packages...
error @semantic-release/changelog@6.0.0: The engine "node" is incompatible with this module. Expected version ">=14.17". Got "12.18.2"
error Found incompatible module.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```