### PR TITLE
Added GetDoubleNonZero Function

### DIFF
--- a/include/emp/bits/BitVector.hpp
+++ b/include/emp/bits/BitVector.hpp
@@ -1558,7 +1558,7 @@ namespace emp {
   /// @return Read-only span of BitVector's bytes.
   std::span<const std::byte> BitVector::GetBytes() const {
     return std::span<const std::byte>(
-      bits.ReinterpretCast<const std::byte>(),
+      bits.ReinterpretCast<const std::byte>().Raw(),
       NumBytes()
     );
   }

--- a/include/emp/math/Random.hpp
+++ b/include/emp/math/Random.hpp
@@ -105,7 +105,14 @@ namespace emp {
     /// @return A pseudo-random double in the provided range.
     inline double GetDouble(const Range<double> range) noexcept {
       return GetDouble(range.GetLower(), range.GetUpper());
-     }
+    }
+
+    /// @return A pseudo-random double value between (0.0, 1.0]
+    inline double GetDoubleNonZero() noexcept {
+      double d = Get() / (double) RAND_CAP;
+      while(d == 0.0) {d = Get() / (double) RAND_CAP;}
+      return d;
+    }
 
 
     /// @return A pseudo-random 32-bit (4 byte) unsigned int value.
@@ -382,10 +389,10 @@ namespace emp {
       // Using Rejection Method and saving of initial exponential random variable
       double expRV2;
       while (1) {
-        expRV2 = -log(GetDouble());
+        expRV2 = -log(GetDoubleNonZero());
         expRV -= (expRV2-1)*(expRV2-1)/2;
         if (expRV > 0) break;
-        expRV = -log(GetDouble());
+        expRV = -log(GetDoubleNonZero());
       }
       if (P(.5)) return expRV2;
       return -expRV2;


### PR DESCRIPTION
I have added the GetDoubleNonZero function so that the doubles are between (0,1]. The original GetDouble function allowed for zeros to be returned, which causes issues in the GetRandNormal function, as log(0) = inf. 

The GetDoubleNonZero function rerolls until a nonzero number is returned. 