### PR TITLE
Deploy docs to github pages

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -168,6 +168,27 @@ jobs:
         with:
           name: doc-coverage
           path: doc/doc-coverage.json
+      - uses: actions/upload-artifact@v2
+        with:
+          name: documentation-html
+          path: doc/_build/html
+  deploy-to-gh-pages:
+    name: Deploy Documentation to GitHub Pages
+    runs-on: ubuntu-22.04
+    needs: test-documentation
+    if: github.ref == 'refs/heads/master'
+    steps:
+      - uses: actions/checkout@v3
+      - name: Download artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: documentation-html
+          path: doc/_build/html
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./doc/_build/html
   deploy-documentation-coverage:
     name: Deploy Documentation Coverage
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Our ReadTheDocs build is consistently timing out, we asked for more time before but it looks like we've been set back to ~20 min build limit... let's try self-hosting via GH Pages