### PR TITLE
Work around bug involving fonts/DOM injection

### DIFF
--- a/examples/web/TextArea.cpp
+++ b/examples/web/TextArea.cpp
@@ -23,11 +23,6 @@ int main()
 {
   doc << "<h1>Testing!</h1>";
 
-  out1_font.SetColor("green");
-  out2_font.SetColor("blue");
-  text_reflect << out1_font;
-  text_reflect2 << out2_font;
-
   text_area.SetCallback([](const std::string & in){
       text_area.SetText("Changed!");
     });
@@ -46,4 +41,10 @@ int main()
                   }, "Update" )
       << "<br>" << text_reflect
       << "<br><br>" << text_reflect2;
+
+  out1_font.SetColor("green");
+  out2_font.SetColor("blue");
+  text_reflect << out1_font;
+  text_reflect2 << out2_font;
+
 }


### PR DESCRIPTION
Adding font before parent container has been added to DOM crashes on pageload.

The current PR rearranges the `examples/TextArea.cpp` example to work around this bug, although this workaround seems to cause text coloring effects to be lost.

We could either merge this PR in as-is to patch the example, or try to diagnose what's going on and fix the underlying issue.

Error message is

```
TextArea.js:6 Uncaught TypeError: ea[v[((v[(a >> 2)] + 68) >> 2)]] is not a function
    at Ml (TextArea.js:6:1555)
    at Array.Sr (TextArea.js:6:9333)
    at qi (TextArea.js:5:252871)
    at Rp (TextArea.js:5:91855)
    at Module._main (TextArea.js:15:78841)
    at callMain (TextArea.js:15:81058)
    at doRun (TextArea.js:15:81455)
    at run (TextArea.js:15:81627)
    at runCaller (TextArea.js:15:80913)
    at removeRunDependency (TextArea.js:15:4729)
Ml	@	TextArea.js:6
Sr	@	TextArea.js:6
qi	@	TextArea.js:5
Rp	@	TextArea.js:5
Module._main	@	TextArea.js:15
callMain	@	TextArea.js:15
doRun	@	TextArea.js:15
run	@	TextArea.js:15
runCaller	@	TextArea.js:15
removeRunDependency	@	TextArea.js:15
applyMemoryInitializer	@	TextArea.js:15
xhr.onload	@	TextArea.js:1
load (async)
readAsync	@	TextArea.js:1
doBrowserLoad	@	TextArea.js:15
runMemoryInitializer	@	TextArea.js:15
receiveInstance	@	TextArea.js:15
receiveInstantiationResult	@	TextArea.js:15
Promise.then (async)
instantiateArrayBuffer	@	TextArea.js:15
instantiateAsync	@	TextArea.js:15
createWasm	@	TextArea.js:15
(anonymous)	@	TextArea.js:15
```