### PR TITLE
Fix CI test coverage failure

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -130,7 +130,7 @@ jobs:
       - name: Set up clang
         uses: egor-tensin/setup-clang@v1
         with:
-          version: 18
+          version: 15
       - uses: actions/checkout@v4
         with:
           submodules: 'recursive'


### PR DESCRIPTION
Failure appears to be due to a gnarly incompatibility between newer clang and force-cover. Hopefully reverting to an older clang will fix it 🙏