### PR TITLE
Remove python3.10-distutils and python3.10-venv from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ SHELL ["/bin/bash", "-c"]
 # Prevent interactive time zone config.
 # adapted from https://askubuntu.com/a/1013396
 ENV DEBIAN_FRONTEND=noninteractive
-ENV SPHINXBUILD="python3.10 -m sphinx"
+ENV SPHINXBUILD="python3.12 -m sphinx"
 
 RUN \
   echo 'Acquire::http::Timeout "60";' >> "/etc/apt/apt.conf.d/99timeout" \
@@ -53,7 +53,7 @@ RUN \
     lsb-release \
     xdg-utils \
     cmake \
-    'python3\.10' \
+    'python3\.12' \
     nodejs \
     npm \
     tar \
@@ -84,13 +84,13 @@ RUN \
     && \
   echo "installed apt packages"
 
-# Set Python 3.10 as the default version of Python 3
+# Set Python 3.12 as the default version of Python 3
 RUN \
-  update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.10 1 \
+  update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 1 \
   && \
-  update-alternatives --set python3 /usr/bin/python3.10 \
+  update-alternatives --set python3 /usr/bin/python3.12 \
   && \
-  ln -s /usr/bin/python3.10 /usr/bin/python
+  ln -s /usr/bin/python3.12 /usr/bin/python
 
 RUN \
   echo $' \n\
@@ -165,19 +165,19 @@ RUN \
   echo "finalized set up dependency versions"
 
 RUN \
-  python3.10 --version \
+  python3.12 --version \
     && \
   python3 --version \
     && \
-  curl -sS https://bootstrap.pypa.io/get-pip.py | python3.10 \
+  curl -sS https://bootstrap.pypa.io/get-pip.py | python3.12 \
     && \
-  python3.10 -m pip install --upgrade --force-reinstall pip virtualenv \
+  python3.12 -m pip install --upgrade --force-reinstall pip virtualenv \
     && \
-  python3.10 -m pip install wheel==0.45.1 setuptools==78.1.0 six==1.16.0 \
+  python3.12 -m pip install wheel==0.45.1 setuptools==78.1.0 six==1.16.0 \
     && \
-  python3.10 -m pip install -r /opt/Empirical/third-party/requirements.txt \
+  python3.12 -m pip install -r /opt/Empirical/third-party/requirements.txt \
     && \
-  python3.10 -m pip install -r /opt/Empirical/doc/requirements.txt \
+  python3.12 -m pip install -r /opt/Empirical/doc/requirements.txt \
     && \
   echo "installed documentation build requirements"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Pull base image.
-FROM ubuntu:focal-20230412
+FROM ubuntu:jammy
 
 COPY . /opt/Empirical
 
@@ -8,7 +8,7 @@ SHELL ["/bin/bash", "-c"]
 # Prevent interactive time zone config.
 # adapted from https://askubuntu.com/a/1013396
 ENV DEBIAN_FRONTEND=noninteractive
-ENV SPHINXBUILD="python3.12 -m sphinx"
+ENV SPHINXBUILD="python3.10 -m sphinx"
 
 RUN \
   echo 'Acquire::http::Timeout "60";' >> "/etc/apt/apt.conf.d/99timeout" \
@@ -30,7 +30,9 @@ RUN \
     && \
   for n in $(seq 1 5); do add-apt-repository -y ppa:ubuntu-toolchain-r/test && sleep 5 && break; done \
     && \
-  for n in $(seq 1 5); do add-apt-repository -y ppa:deadsnakes/ppa && sleep 5 && break; done \
+  for n in $(seq 1 5); do add-apt-repository -y ppa:mozillateam/ppa && sleep 5 && break; done \
+    && \
+  printf 'Package: firefox*\nPin: release o=LP-PPA-mozillateam\nPin-Priority: 1001\n' > /etc/apt/preferences.d/mozilla-firefox \
     && \
   for n in $(seq 1 5); do apt-get update -y && sleep 5 && break; done \
     && \
@@ -53,7 +55,7 @@ RUN \
     lsb-release \
     xdg-utils \
     cmake \
-    'python3\.12' \
+    python3.10 \
     nodejs \
     npm \
     tar \
@@ -84,13 +86,13 @@ RUN \
     && \
   echo "installed apt packages"
 
-# Set Python 3.12 as the default version of Python 3
+# Set Python 3.10 as the default version of Python 3
 RUN \
-  update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 1 \
+  update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.10 1 \
   && \
-  update-alternatives --set python3 /usr/bin/python3.12 \
+  update-alternatives --set python3 /usr/bin/python3.10 \
   && \
-  ln -s /usr/bin/python3.12 /usr/bin/python
+  ln -s /usr/bin/python3.10 /usr/bin/python
 
 RUN \
   echo $' \n\
@@ -165,19 +167,19 @@ RUN \
   echo "finalized set up dependency versions"
 
 RUN \
-  python3.12 --version \
+  python3.10 --version \
     && \
   python3 --version \
     && \
-  curl -sS https://bootstrap.pypa.io/get-pip.py | python3.12 \
+  curl -sS https://bootstrap.pypa.io/get-pip.py | python3.10 \
     && \
-  python3.12 -m pip install --upgrade --force-reinstall pip virtualenv \
+  python3.10 -m pip install --upgrade --force-reinstall pip virtualenv \
     && \
-  python3.12 -m pip install wheel==0.45.1 setuptools==78.1.0 six==1.16.0 \
+  python3.10 -m pip install wheel==0.45.1 setuptools==78.1.0 six==1.16.0 \
     && \
-  python3.12 -m pip install -r /opt/Empirical/third-party/requirements.txt \
+  python3.10 -m pip install -r /opt/Empirical/third-party/requirements.txt \
     && \
-  python3.12 -m pip install -r /opt/Empirical/doc/requirements.txt \
+  python3.10 -m pip install -r /opt/Empirical/doc/requirements.txt \
     && \
   echo "installed documentation build requirements"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,8 +54,6 @@ RUN \
     xdg-utils \
     cmake \
     'python3\.10' \
-    'python3\.10-distutils' \
-    'python3\.10-venv' \
     nodejs \
     npm \
     tar \
@@ -146,7 +144,7 @@ RUN \
     && \
   echo "make xvfb daemon script executable"
 
-ENV DISPLAY :99
+ENV DISPLAY=:99
 
 # magic from https://github.com/puppeteer/puppeteer/issues/3451#issuecomment-523961368
 RUN echo 'kernel.unprivileged_userns_clone=1' > /etc/sysctl.d/userns.conf


### PR DESCRIPTION
These packages have been removed from the deadsnakes PPA for Ubuntu
Focal and are no longer available, causing the Docker build to fail.

Neither package is needed:
- pip is installed via get-pip.py which doesn't require distutils
- virtualenv is installed via pip, replacing the need for the venv package

Also fix legacy ENV format warning (ENV key value -> ENV key=value).

https://claude.ai/code/session_01UWALAV2tXVZ3pDtg88Npo9