### PR TITLE
Fix prefab layout issues for long setting names (RE#548)

### DIFF
--- a/include/emp/prefab/DefaultPrefabStyles.less
+++ b/include/emp/prefab/DefaultPrefabStyles.less
@@ -111,11 +111,22 @@
 
 .display_group, .settings_group {
   display: grid;
-  grid-template-columns: auto 1fr;
+  // Capping the label column stops a long setting name from squeezing
+  // the value column down to nothing (issue #548).
+  grid-template-columns: minmax(0, 55%) minmax(150px, 1fr);
   grid-auto-rows: auto;
   grid-auto-flow: row dense;
   align-items: center;
   justify-items: stretch;
+}
+
+// Let long setting labels wrap instead of forcing the label column wide.
+.settings_group .value_box > .btn,
+.display_group .value_box > .btn {
+  white-space: normal;
+  overflow-wrap: anywhere;
+  min-width: 0;
+  text-align: left;
 }
 
 .config_controls {
@@ -161,13 +172,7 @@
   display: flex;
   flex-flow: row nowrap;
   grid-column-end: -1; // Spans to last column from wherever it is autoplaced
-
-  //min-width: 270px:
-  // BUG: Setting min-width ideally would result in auto-placement
-  // in a new row when the grid is too small to contain the view
-  // in the second column. However, instead it just forces the
-  // grid out of the viewport. Waiting on widespread subgrid support
-  // to fix, *sigh*.
+  min-width: 0; // let this grid item shrink below its content size instead of overflowing
 
   // This just adds some spacing between components in the view
   > :not(:last-child) {
@@ -178,12 +183,18 @@
   input {
     &[type=range] {
       flex: 1 1 auto;
+      min-width: 30px;
     }
     &[type=number] {
       flex: 0 1 100px;
+      // Firefox reserves a fixed-width spin-button, so a narrower
+      // number input just hides the digits instead of shrinking them
+      // (issue #548). Keep enough room for the text to stay visible.
+      min-width: 70px;
     }
     &[type=text] {
       flex: 1 1 auto;
+      min-width: 0;
     }
   }
 }


### PR DESCRIPTION
Prevent long setting labels from squeezing value columns down to nothing by:
- Capping the label column to 55% max width with minmax()
- Adding word wrapping styles for label buttons
- Replacing obsolete min-width workaround with proper shrink-to-fit behavior
- Adding min-width constraints to inputs to prevent Firefox number input overflow

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EjgX5KS3bVyoJwp1DMhnCo