### PR TITLE
Make the Min/Max initializer_list overloads instantiable

### DIFF
--- a/include/emp/math/math.hpp
+++ b/include/emp/math/math.hpp
@@ -302,9 +302,11 @@ namespace emp {
   }
 
   /// A version of Min that allows a variable number of inputs to be compared.
+  /// Returns by value: the backing array of a braced list ends its lifetime at
+  /// the end of the full expression, so a reference into it would dangle.
   template <typename T>
-  const T & Min(std::initializer_list<const T &> lst) {
-    emp_assert(lst.size > 0);  // Nothing to return if nothing in the list!
+  T Min(std::initializer_list<T> lst) {
+    emp_assert(lst.size() > 0);  // Nothing to return if nothing in the list!
     auto min_found = lst.begin();
     for (auto it = lst.begin() + 1; it < lst.end(); it++) {
       if (*it < *min_found) { min_found = it; }
@@ -313,9 +315,10 @@ namespace emp {
   }
 
   /// A version of Max that allows a variable number of inputs to be compared.
+  /// Returns by value, for the same reason as Min above.
   template <typename T>
-  const T & Max(std::initializer_list<const T &> lst) {
-    emp_assert(lst.size > 0);  // Nothing to return if nothing in the list!
+  T Max(std::initializer_list<T> lst) {
+    emp_assert(lst.size() > 0);  // Nothing to return if nothing in the list!
     auto max_found = lst.begin();
     for (auto it = lst.begin() + 1; it < lst.end(); it++) {
       if (*it > *max_found) { max_found = it; }


### PR DESCRIPTION
Fixes #550.

`std::initializer_list<const T &>` is ill-formed, so the two list overloads of `emp::Min` and `emp::Max` could never be instantiated. Any call to them failed inside `<initializer_list>` itself:

```
initializer_list:63:12: error: '__begin_' declared as a pointer to a reference of type 'const int &'
```

with `emp::Min({3, 1, 2})` as the whole test case.

The overloads now take `std::initializer_list<T>` and return by value. Returning a reference would dangle: the backing array of a braced list ends its lifetime at the end of the full expression that contains it, so a `const T &` into it is already gone by the time the caller reads it.

`lst.size` also gained the parentheses it was missing. As written it took the address of the member function, which is never null, so the assert could not fire.

Checked with `c++ -std=c++20 -I include -fsyntax-only` on a file calling both: it fails on master and compiles here.
