### PR TITLE
Name the two parameters BitFieldsToString actually takes

### DIFF
--- a/include/emp/bits/bitset_utils.hpp
+++ b/include/emp/bits/bitset_utils.hpp
@@ -43,7 +43,8 @@ namespace emp {
   }
 
   /// @brief Convert a series of bit fields to a string.
-  /// @param field A single bit field to convert to a string.
+  /// @param bits The bit fields to convert to a string.
+  /// @param count How many bit fields to read.
   [[maybe_unused]] [[nodiscard]] std::string BitFieldsToString(bits_field_t * bits, size_t count) {
     std::stringstream ss;
     for (size_t i = 0; i < count; ++i) {


### PR DESCRIPTION
`BitFieldsToString(bits_field_t * bits, size_t count)` documents a parameter called `field`, which the function does not take, and says nothing about the two it does.

Doxygen drops an unknown `@param` and leaves the real ones undocumented, so the rendered page for this function has no parameter list at all.
